### PR TITLE
feat(#16): banner 조회 API

### DIFF
--- a/src/main/java/site/archive/api/v2/BannerControllerV2.java
+++ b/src/main/java/site/archive/api/v2/BannerControllerV2.java
@@ -1,0 +1,25 @@
+package site.archive.api.v2;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.archive.api.v2.dto.BannerListResponseDto;
+import site.archive.domain.banner.BannerService;
+
+@RestController
+@RequestMapping("/api/v2/banner")
+@RequiredArgsConstructor
+public class BannerControllerV2 {
+
+    private final BannerService bannerService;
+
+    @GetMapping
+    public ResponseEntity<BannerListResponseDto> archiveCommunityBannerView() {
+        return ResponseEntity.ok(bannerService.getAllBanner());
+    }
+
+}
+
+

--- a/src/main/java/site/archive/api/v2/dto/BannerListResponseDto.java
+++ b/src/main/java/site/archive/api/v2/dto/BannerListResponseDto.java
@@ -1,0 +1,6 @@
+package site.archive.api.v2.dto;
+
+import java.util.List;
+
+public record BannerListResponseDto(List<BannerResponseDto> banners) {
+}

--- a/src/main/java/site/archive/api/v2/dto/BannerResponseDto.java
+++ b/src/main/java/site/archive/api/v2/dto/BannerResponseDto.java
@@ -1,0 +1,4 @@
+package site.archive.api.v2.dto;
+
+public record BannerResponseDto(String summaryImage, String mainImage) {
+}

--- a/src/main/java/site/archive/api/v2/dto/BannerResponseDto.java
+++ b/src/main/java/site/archive/api/v2/dto/BannerResponseDto.java
@@ -1,4 +1,4 @@
 package site.archive.api.v2.dto;
 
-public record BannerResponseDto(String summaryImage, String mainImage) {
+public record BannerResponseDto(String type, String summaryImage, String mainContent) {
 }

--- a/src/main/java/site/archive/domain/banner/BannerRepository.java
+++ b/src/main/java/site/archive/domain/banner/BannerRepository.java
@@ -1,0 +1,12 @@
+package site.archive.domain.banner;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.archive.domain.banner.entity.Banner;
+
+import java.util.List;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    List<Banner> findAllByOrderByCreatedAtDesc();
+
+}

--- a/src/main/java/site/archive/domain/banner/BannerService.java
+++ b/src/main/java/site/archive/domain/banner/BannerService.java
@@ -1,0 +1,21 @@
+package site.archive.domain.banner;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.archive.api.v2.dto.BannerListResponseDto;
+import site.archive.api.v2.dto.BannerResponseDto;
+
+@Service
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    public BannerListResponseDto getAllBanner() {
+        var bannerResponse = bannerRepository.findAllByOrderByCreatedAtDesc().stream()
+                                             .map(banner -> new BannerResponseDto(banner.getSummaryImage(), banner.getMainImage()))
+                                             .toList();
+        return new BannerListResponseDto(bannerResponse);
+    }
+
+}

--- a/src/main/java/site/archive/domain/banner/BannerService.java
+++ b/src/main/java/site/archive/domain/banner/BannerService.java
@@ -13,7 +13,9 @@ public class BannerService {
 
     public BannerListResponseDto getAllBanner() {
         var bannerResponse = bannerRepository.findAllByOrderByCreatedAtDesc().stream()
-                                             .map(banner -> new BannerResponseDto(banner.getSummaryImage(), banner.getMainImage()))
+                                             .map(banner -> new BannerResponseDto(banner.getType().toString(),
+                                                                                  banner.getSummaryImage(),
+                                                                                  banner.getMainContent()))
                                              .toList();
         return new BannerListResponseDto(bannerResponse);
     }

--- a/src/main/java/site/archive/domain/banner/entity/Banner.java
+++ b/src/main/java/site/archive/domain/banner/entity/Banner.java
@@ -9,6 +9,8 @@ import site.archive.domain.common.BaseTimeEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -30,7 +32,11 @@ public class Banner extends BaseTimeEntity {
     @Column(name = "summary_image")
     private String summaryImage;
 
-    @Column(name = "main_image")
-    private String mainImage;
+    @Column(name = "main_content")
+    private String mainContent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private BannerType type;
 
 }

--- a/src/main/java/site/archive/domain/banner/entity/Banner.java
+++ b/src/main/java/site/archive/domain/banner/entity/Banner.java
@@ -1,0 +1,36 @@
+package site.archive.domain.banner.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+import site.archive.domain.common.BaseTimeEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "banner")
+@SQLDelete(sql = "UPDATE banner SET is_deleted = true WHERE banner_id=?")
+@Where(clause = "is_deleted = false")
+public class Banner extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "banner_id")
+    private Long id;
+
+    @Column(name = "summary_image")
+    private String summaryImage;
+
+    @Column(name = "main_image")
+    private String mainImage;
+
+}

--- a/src/main/java/site/archive/domain/banner/entity/BannerType.java
+++ b/src/main/java/site/archive/domain/banner/entity/BannerType.java
@@ -1,0 +1,8 @@
+package site.archive.domain.banner.entity;
+
+public enum BannerType {
+
+    IMAGE,
+    URL,
+
+}


### PR DESCRIPTION
from #16 

**Goals**

- banner 조회 API

- Type (Image/Url)
  - 추후 확장성을 위해 타입을 분리. 현재로선 Image만 운영

- 반환 예시
```json
{
    "banners": [
        {
            "type": "URL",
            "summaryImage": "https://~/summary.png",
            "mainContent": "https://~/some-url"
        },
        {
            "type": "IMAGE",
            "summaryImage": "https://~/summary.png",
            "mainContent": "https://~/main.png"
        }
    ]
}
```