### PR TITLE
feat: Archive block count logic

### DIFF
--- a/archive-application/src/main/java/site/archive/service/archive/ArchiveCommunityService.java
+++ b/archive-application/src/main/java/site/archive/service/archive/ArchiveCommunityService.java
@@ -8,17 +8,20 @@ import site.archive.domain.archive.custom.ArchivePageable;
 import site.archive.dto.v2.ArchiveCommunityResponseDto;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 @Service
 @RequiredArgsConstructor
 public class ArchiveCommunityService {
 
     private static final int ARCHIVE_COMMUNITY_PAGE_ELEMENT_SIZE = 15;
+    private static final int BLOCK_ARCHIVE_REPORT_COUNT = 5;
 
     private final ArchiveRepository archiveRepository;
 
     public List<ArchiveCommunityResponseDto> getCommunityFirstPage(Long currentUserIdx, ArchivePageable pageable) {
         var archiveIds = archiveRepository.findFirstPageOnlyPublic(pageable, ARCHIVE_COMMUNITY_PAGE_ELEMENT_SIZE).stream()
+                                          .filter(lessThanBlockReportCount())
                                           .map(Archive::getId).toList();
         return archiveRepository.findByIdInWithLike(archiveIds, pageable).stream()
                                 .map(archive -> ArchiveCommunityResponseDto.from(archive, currentUserIdx,
@@ -28,11 +31,18 @@ public class ArchiveCommunityService {
 
     public List<ArchiveCommunityResponseDto> getCommunityNextPage(Long currentUserIdx, ArchivePageable pageable) {
         var archiveIds = archiveRepository.findNextPageOnlyPublic(pageable, ARCHIVE_COMMUNITY_PAGE_ELEMENT_SIZE).stream()
+                                          .filter(lessThanBlockReportCount())
                                           .map(Archive::getId).toList();
         return archiveRepository.findByIdInWithLike(archiveIds, pageable).stream()
                                 .map(archive -> ArchiveCommunityResponseDto.from(archive, currentUserIdx,
                                                                                  pageable.getSortType().convertToMillis(archive)))
                                 .toList();
+    }
+
+    private Predicate<Archive> lessThanBlockReportCount() {
+        return archive -> archive.getReports().stream()
+                                 .filter(report -> !report.getIsDeleted())
+                                 .count() < BLOCK_ARCHIVE_REPORT_COUNT;
     }
 
 }

--- a/archive-domain/src/main/java/site/archive/domain/archive/Archive.java
+++ b/archive-domain/src/main/java/site/archive/domain/archive/Archive.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.Where;
 import site.archive.domain.archive.converter.CompanionsConverter;
 import site.archive.domain.common.BaseTimeEntity;
 import site.archive.domain.like.Like;
+import site.archive.domain.report.Report;
 import site.archive.domain.user.BaseUser;
 
 import javax.persistence.CascadeType;
@@ -44,6 +45,9 @@ public class Archive extends BaseTimeEntity {
     private final List<Like> likes = new ArrayList<>();
     @OneToMany(mappedBy = "archive", cascade = CascadeType.ALL)
     private final List<ArchiveImage> archiveImages = new ArrayList<>();
+    @OneToMany(mappedBy = "archive", cascade = CascadeType.ALL)
+    private final List<Report> reports = new ArrayList<>();
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "archive_id")

--- a/archive-domain/src/main/java/site/archive/domain/archive/custom/ArchiveCustomRepositoryImpl.java
+++ b/archive-domain/src/main/java/site/archive/domain/archive/custom/ArchiveCustomRepositoryImpl.java
@@ -44,7 +44,8 @@ public class ArchiveCustomRepositoryImpl implements ArchiveCustomRepository {
 
     @Override
     public List<Archive> findFirstPageOnlyPublic(ArchivePageable pageable, int pageElementSize) {
-        var archiveQuery = archiveSelectQueryWithAuthor(pageable);
+        var archiveQuery = archiveSelectQueryWithAuthor(pageable)
+                               .leftJoin(QArchive.archive.reports).fetchJoin();
         var whereOnlyPublic = QArchive.archive.isPublic.eq(true);
         return whereEmotionIfExists(archiveQuery, pageable.getEmotion())
                    .where(whereOnlyPublic)
@@ -54,7 +55,8 @@ public class ArchiveCustomRepositoryImpl implements ArchiveCustomRepository {
 
     @Override
     public List<Archive> findNextPageOnlyPublic(ArchivePageable pageable, int pageElementSize) {
-        var archiveQuery = archiveSelectQueryWithAuthor(pageable);
+        var archiveQuery = archiveSelectQueryWithAuthor(pageable)
+                               .leftJoin(QArchive.archive.reports).fetchJoin();
         var whereOnlyPublic = QArchive.archive.isPublic.eq(true);
         return whereEmotionIfExists(archiveQuery, pageable.getEmotion())
                    .where(whereOnlyPublic, whereNextPage(pageable))


### PR DESCRIPTION
- 아카이브 게시물에 대한 신고회수가 특정 회수를 넘는 경우, 조회 불가 (`block`)
  - 일단 특정횟수를 `5`로 설정. 5개 이상의 신고가 들어가는 경우, 아카이브 커뮤니티에서 조회불가능 (개인 유저 게시물에선 조회가능)