### PR TITLE
feat: user nickname field 추가

### DIFF
--- a/archive-application/src/main/java/site/archive/dto/v1/user/BaseUserDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v1/user/BaseUserDto.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import site.archive.common.DateTimeUtil;
 import site.archive.domain.user.BaseUser;
+import site.archive.domain.user.UserRole;
 
 import java.time.LocalDateTime;
 
@@ -13,12 +14,14 @@ public class BaseUserDto {
 
     private final Long userId;
     private final String mailAddress;
+    private final UserRole userRole;
     private final LocalDateTime createdAt;
     private final String profileImage;
 
     public static BaseUserDto from(BaseUser baseUser) {
         return new BaseUserDto(baseUser.getId(),
                                baseUser.getMailAddress(),
+                               baseUser.getRole(),
                                baseUser.getCreatedAt(),
                                baseUser.getProfileImage());
     }

--- a/archive-application/src/main/java/site/archive/dto/v1/user/BaseUserDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v1/user/BaseUserDto.java
@@ -19,16 +19,22 @@ public class BaseUserDto {
     private final UserRole userRole;
     private final LocalDateTime createdAt;
     private final String profileImage;
+    private final String nickname;
 
     // mutable field
     private String userType;
 
     public static BaseUserDto from(BaseUser baseUser) {
+        var nickname = baseUser.getNickname() == null
+                       ? baseUser.getMailAddressId()
+                       : baseUser.getNickname();
+
         return new BaseUserDto(baseUser.getId(),
                                baseUser.getMailAddress(),
                                baseUser.getRole(),
                                baseUser.getCreatedAt(),
                                baseUser.getProfileImage(),
+                               nickname,
                                baseUser.getUserType());
     }
 

--- a/archive-application/src/main/java/site/archive/dto/v1/user/BaseUserDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v1/user/BaseUserDto.java
@@ -1,5 +1,6 @@
 package site.archive.dto.v1.user;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import site.archive.common.DateTimeUtil;
@@ -8,6 +9,7 @@ import site.archive.domain.user.UserRole;
 
 import java.time.LocalDateTime;
 
+@AllArgsConstructor
 @RequiredArgsConstructor
 @Getter
 public class BaseUserDto {
@@ -18,16 +20,24 @@ public class BaseUserDto {
     private final LocalDateTime createdAt;
     private final String profileImage;
 
+    // mutable field
+    private String userType;
+
     public static BaseUserDto from(BaseUser baseUser) {
         return new BaseUserDto(baseUser.getId(),
                                baseUser.getMailAddress(),
                                baseUser.getRole(),
                                baseUser.getCreatedAt(),
-                               baseUser.getProfileImage());
+                               baseUser.getProfileImage(),
+                               baseUser.getUserType());
     }
 
     public String getCreatedAt() {
         return DateTimeUtil.DATE_TIME_FORMATTER.format(this.createdAt);
+    }
+
+    public void updateSpecificUserType(String userType) {
+        this.userType = userType;
     }
 
 }

--- a/archive-application/src/main/java/site/archive/dto/v1/user/BaseUserDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v1/user/BaseUserDto.java
@@ -25,16 +25,12 @@ public class BaseUserDto {
     private String userType;
 
     public static BaseUserDto from(BaseUser baseUser) {
-        var nickname = baseUser.getNickname() == null
-                       ? baseUser.getMailAddressId()
-                       : baseUser.getNickname();
-
         return new BaseUserDto(baseUser.getId(),
                                baseUser.getMailAddress(),
                                baseUser.getRole(),
                                baseUser.getCreatedAt(),
                                baseUser.getProfileImage(),
-                               nickname,
+                               baseUser.getNickname(),
                                baseUser.getUserType());
     }
 

--- a/archive-application/src/main/java/site/archive/dto/v2/ArchiveCommunityResponseDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/ArchiveCommunityResponseDto.java
@@ -38,8 +38,8 @@ public class ArchiveCommunityResponseDto {
                                           .emotion(archive.getEmotion())
                                           .mainImage(archive.getMainImage())
                                           .authorId(author.getId())
-                                          .authorNickname("")        // TODO: 추가필요
-                                          .authorProfileImage("")    // TODO: 추가필요
+                                          .authorNickname(author.getNickname())
+                                          .authorProfileImage(author.getProfileImage())
                                           .isLiked(isLiked)
                                           .likeCount(likeCount)
                                           .dateMilli(dateMilli)

--- a/archive-application/src/main/java/site/archive/dto/v2/ArchiveLikeResponseDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/ArchiveLikeResponseDto.java
@@ -39,8 +39,8 @@ public class ArchiveLikeResponseDto {
                                      .emotion(archive.getEmotion())
                                      .mainImage(archive.getMainImage())
                                      .authorId(author.getId())
-                                     .authorNickname("")        // TODO: 추가필요
-                                     .authorProfileImage("")    // TODO: 추가필요
+                                     .authorNickname(author.getNickname())
+                                     .authorProfileImage(author.getProfileImage())
                                      .isLiked(isLiked)
                                      .likeCount(likeCount)
                                      .build();

--- a/archive-application/src/main/java/site/archive/dto/v2/NicknameDuplicateResponseDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/NicknameDuplicateResponseDto.java
@@ -1,0 +1,4 @@
+package site.archive.dto.v2;
+
+public record NicknameDuplicateResponseDto(boolean isDuplicatedNickname) {
+}

--- a/archive-application/src/main/java/site/archive/dto/v2/UserNicknameUpdateRequest.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/UserNicknameUpdateRequest.java
@@ -1,0 +1,4 @@
+package site.archive.dto.v2;
+
+public record UserNicknameUpdateRequest(String nickname) {
+}

--- a/archive-application/src/main/java/site/archive/service/user/UserService.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import site.archive.common.exception.common.DuplicateResourceException;
+import site.archive.common.exception.common.DuplicateFieldValueException;
 import site.archive.common.exception.common.ResourceNotFoundException;
 import site.archive.domain.user.OAuthUser;
 import site.archive.domain.user.OAuthUserRepository;
@@ -50,7 +50,7 @@ public class UserService {
     @Transactional
     public void updateUserNickname(long userId, String nickname) {
         if (existsNickname(nickname)) {
-            throw new DuplicateResourceException("nickname");
+            throw new DuplicateFieldValueException("nickname", nickname);
         }
         userRepository.updateNickName(userId, nickname);
     }

--- a/archive-application/src/main/java/site/archive/service/user/UserService.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserService.java
@@ -37,6 +37,10 @@ public class UserService {
         return userRepository.findByMailAddress(email).isPresent();
     }
 
+    public boolean existsNickname(String nickname) {
+        return userRepository.findByNickname(nickname).isPresent();
+    }
+
     @Transactional
     public void deleteUser(long userId) {
         userRepository.deleteById(userId);

--- a/archive-application/src/main/java/site/archive/service/user/UserService.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserService.java
@@ -5,6 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.archive.common.exception.common.ResourceNotFoundException;
+import site.archive.domain.user.OAuthUser;
+import site.archive.domain.user.OAuthUserRepository;
+import site.archive.domain.user.PasswordUserRepository;
 import site.archive.domain.user.UserRepository;
 import site.archive.dto.v1.user.BaseUserDto;
 
@@ -15,11 +18,19 @@ import site.archive.dto.v1.user.BaseUserDto;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordUserRepository passwordUserRepository;
+    private final OAuthUserRepository oAuthUserRepository;
 
     public BaseUserDto findUserById(long userId) {
         return userRepository.findById(userId)
                              .map(BaseUserDto::from)
                              .orElseThrow(() -> new ResourceNotFoundException("아이디에 해당하는 유저가 존재하지 않습니다."));
+    }
+
+    public BaseUserDto findSpecificUserById(long userId) {
+        var user = findUserById(userId);
+        updateUserTypeWithProviderWhenOAuthUser(userId, user);
+        return user;
     }
 
     public boolean existsEmail(String email) {
@@ -29,6 +40,15 @@ public class UserService {
     @Transactional
     public void deleteUser(long userId) {
         userRepository.deleteById(userId);
+    }
+
+    private void updateUserTypeWithProviderWhenOAuthUser(long userId, BaseUserDto user) {
+        if (OAuthUser.OAUTH_TYPE.equals(user.getUserType())) {
+            var oAuthType = oAuthUserRepository.findById(userId)
+                                               .map(oAuthUser -> oAuthUser.getOAuthProvider().toString())
+                                               .orElseThrow(() -> new ResourceNotFoundException("아이디에 해당하는 OAuth 유저가 존재하지 않습니다."));
+            user.updateSpecificUserType(oAuthType);
+        }
     }
 
 }

--- a/archive-application/src/main/java/site/archive/service/user/UserService.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.archive.common.exception.common.DuplicateResourceException;
 import site.archive.common.exception.common.ResourceNotFoundException;
 import site.archive.domain.user.OAuthUser;
 import site.archive.domain.user.OAuthUserRepository;
@@ -48,6 +49,9 @@ public class UserService {
 
     @Transactional
     public void updateUserNickname(long userId, String nickname) {
+        if (existsNickname(nickname)) {
+            throw new DuplicateResourceException("nickname");
+        }
         userRepository.updateNickName(userId, nickname);
     }
 

--- a/archive-application/src/main/java/site/archive/service/user/UserService.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserService.java
@@ -42,6 +42,11 @@ public class UserService {
         userRepository.deleteById(userId);
     }
 
+    @Transactional
+    public void updateUserNickname(long userId, String nickname) {
+        userRepository.updateNickName(userId, nickname);
+    }
+
     private void updateUserTypeWithProviderWhenOAuthUser(long userId, BaseUserDto user) {
         if (OAuthUser.OAUTH_TYPE.equals(user.getUserType())) {
             var oAuthType = oAuthUserRepository.findById(userId)

--- a/archive-application/src/test/java/site/archive/service/archive/ArchiveServiceTest.java
+++ b/archive-application/src/test/java/site/archive/service/archive/ArchiveServiceTest.java
@@ -11,6 +11,7 @@ import site.archive.domain.archive.Archive;
 import site.archive.domain.archive.ArchiveRepository;
 import site.archive.domain.archive.Emotion;
 import site.archive.domain.user.BaseUser;
+import site.archive.domain.user.PasswordUser;
 import site.archive.domain.user.UserInfo;
 import site.archive.domain.user.UserRepository;
 import site.archive.domain.user.UserRole;
@@ -28,7 +29,7 @@ import static org.mockito.BDDMockito.given;
 class ArchiveServiceTest {
 
     private static final long USER_ID = 1L;
-    private static final BaseUser USER = new BaseUser(USER_ID, "mail", UserRole.GENERAL, null);
+    private static final BaseUser USER = new BaseUser(USER_ID, "mail", UserRole.GENERAL, null, PasswordUser.PASSWORD_TYPE);
 
     @Mock
     ArchiveRepository archiveRepository;

--- a/archive-application/src/test/java/site/archive/service/archive/ArchiveServiceTest.java
+++ b/archive-application/src/test/java/site/archive/service/archive/ArchiveServiceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.BDDMockito.given;
 class ArchiveServiceTest {
 
     private static final long USER_ID = 1L;
-    private static final BaseUser USER = new BaseUser(USER_ID, "mail", UserRole.GENERAL, null, PasswordUser.PASSWORD_TYPE);
+    private static final BaseUser USER = new BaseUser(USER_ID, "mail", UserRole.GENERAL, null, PasswordUser.PASSWORD_TYPE, "nickname");
 
     @Mock
     ArchiveRepository archiveRepository;

--- a/archive-common/src/main/java/site/archive/common/exception/ExceptionCode.java
+++ b/archive-common/src/main/java/site/archive/common/exception/ExceptionCode.java
@@ -21,6 +21,7 @@ public enum ExceptionCode {
     DUPLICATED_RESOURCE(HttpStatus.CONFLICT, "Common001", "이미 존재하는 리소스 입니다"),
     NOT_FOUND_RESOURCE(HttpStatus.BAD_REQUEST, "Common002", "존재 하지 않는 리소스 입니다"),
     UNAUTHORIZED_RESOURCE(HttpStatus.FORBIDDEN, "Common003", "리소스에 대한 접근권한이 없습니다"),
+    DUPLICATED_FIELD_VALUE(HttpStatus.BAD_REQUEST, "Common004", "중복된 값 입니다"),
 
     // User
     LOGIN_FAIL(HttpStatus.BAD_REQUEST, "User001", "로그인에 실패했습니다"),

--- a/archive-common/src/main/java/site/archive/common/exception/ExceptionCode.java
+++ b/archive-common/src/main/java/site/archive/common/exception/ExceptionCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionCode {
 
     // Global
-    NO_VALUE(HttpStatus.BAD_REQUEST, "Global001", "필요한 값이 없거나 문제가 없습니다."),
+    NO_VALUE(HttpStatus.BAD_REQUEST, "Global001", "필요한 값이 없거나 전달된 값에 문제가 있습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Global002", "Invalid Input Value"),
     TYPE_MISMATCH_VALUE(HttpStatus.BAD_REQUEST, "Global003", "타입(enum)이 일치하지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Global004", "Invalid Input Value"),

--- a/archive-common/src/main/java/site/archive/common/exception/common/DuplicateFieldValueException.java
+++ b/archive-common/src/main/java/site/archive/common/exception/common/DuplicateFieldValueException.java
@@ -1,0 +1,15 @@
+package site.archive.common.exception.common;
+
+import site.archive.common.exception.BaseException;
+import site.archive.common.exception.ExceptionCode;
+
+public class DuplicateFieldValueException extends BaseException {
+
+    private static final String DUPLICATED_FILED_MESSAGE = "'%s'은 중복된 %s 입니다. 다른 %s을 사용해주세요.";
+
+    public DuplicateFieldValueException(String duplicatedField, String duplicatedValue) {
+        super(DUPLICATED_FILED_MESSAGE.formatted(duplicatedValue, duplicatedField, duplicatedField),
+              ExceptionCode.DUPLICATED_FIELD_VALUE);
+    }
+
+}

--- a/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
@@ -3,7 +3,6 @@ package site.archive.domain.user;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -38,17 +37,18 @@ public class BaseUser extends BaseTimeEntity {
     @Setter
     private Long id;
 
-    @NonNull
     @Column(name = "mail_address", unique = true)
     private String mailAddress;
 
-    @NonNull
     @Enumerated(EnumType.STRING)
     @Column(name = "user_role")
     private UserRole role;
 
     @Column(name = "profile_image")
     private String profileImage;
+
+    @Column(name = "user_type")
+    private String userType;
 
     public BaseUser(Long id) {
         this.id = id;

--- a/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
@@ -66,8 +66,8 @@ public class BaseUser extends BaseTimeEntity {
         return new UserInfo(mailAddress, role, id);
     }
 
-    public String getMailAddressId() {
-        return mailAddress.substring(0, mailAddress.indexOf('@'));
+    public String getNickname() {
+        return nickname != null ? nickname : mailAddress.substring(0, mailAddress.indexOf('@'));
     }
 
 }

--- a/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
@@ -50,6 +50,9 @@ public class BaseUser extends BaseTimeEntity {
     @Column(name = "user_type")
     private String userType;
 
+    @Column(name = "nickname")
+    private String nickname;
+
     public BaseUser(Long id) {
         this.id = id;
     }
@@ -61,6 +64,10 @@ public class BaseUser extends BaseTimeEntity {
 
     public UserInfo convertToUserInfo() {
         return new UserInfo(mailAddress, role, id);
+    }
+
+    public String getMailAddressId() {
+        return mailAddress.substring(0, mailAddress.indexOf('@'));
     }
 
 }

--- a/archive-domain/src/main/java/site/archive/domain/user/OAuthUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/OAuthUser.java
@@ -12,9 +12,11 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "oauth_user")
-@DiscriminatorValue("oauth")
+@DiscriminatorValue(OAuthUser.OAUTH_TYPE)
 @NoArgsConstructor
 public class OAuthUser extends BaseUser {
+
+    public static final String OAUTH_TYPE = "oauth";
 
     @Getter
     @Column(name = "oauth_provider")

--- a/archive-domain/src/main/java/site/archive/domain/user/OAuthUserRepository.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/OAuthUserRepository.java
@@ -1,0 +1,6 @@
+package site.archive.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OAuthUserRepository extends JpaRepository<OAuthUser, Long> {
+}

--- a/archive-domain/src/main/java/site/archive/domain/user/PasswordUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/PasswordUser.java
@@ -11,10 +11,12 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "password_user")
-@DiscriminatorValue("password")
+@DiscriminatorValue(PasswordUser.PASSWORD_TYPE)
 @DynamicInsert
 @NoArgsConstructor
 public class PasswordUser extends BaseUser {
+
+    public static final String PASSWORD_TYPE = "password";
 
     @Getter
     @Column(name = "password")

--- a/archive-domain/src/main/java/site/archive/domain/user/UserRepository.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/UserRepository.java
@@ -21,4 +21,9 @@ public interface UserRepository extends JpaRepository<BaseUser, Long> {
     void updateUserProfileImage(@Param("userId") Long userId,
                                 @Param("profileImage") String profileImageUri);
 
+    @Modifying
+    @Query("update BaseUser u set u.nickname = :nickname where u.id = :userId")
+    void updateNickName(@Param("userId") Long userId,
+                        @Param("nickname") String nickname);
+
 }

--- a/archive-domain/src/main/java/site/archive/domain/user/UserRepository.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/UserRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<BaseUser, Long> {
     Optional<BaseUser> findByMailAddress(String mailAddress);
 
+    Optional<BaseUser> findByNickname(String nickname);
+
     @Modifying
     @Query("update BaseUser u set u.isDeleted = true where u.id = :userId")
     void deleteById(@NotNull @Param("userId") Long userId);

--- a/archive-web/src/main/java/site/archive/web/api/interceptor/InjectTokenInterceptor.java
+++ b/archive-web/src/main/java/site/archive/web/api/interceptor/InjectTokenInterceptor.java
@@ -1,0 +1,32 @@
+package site.archive.web.api.interceptor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import site.archive.web.config.security.token.HttpAuthTokenSupport;
+import site.archive.web.config.security.token.TokenProvider;
+import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+public class InjectTokenInterceptor implements HandlerInterceptor {
+
+    private final TokenProvider tokenProvider;
+    private final HttpAuthTokenSupport tokenSupport;
+
+    @Override
+    public void postHandle(HttpServletRequest request,
+                           HttpServletResponse response,
+                           Object handler,
+                           ModelAndView modelAndView) {
+        if (SecurityContextHolder.getContext().getAuthentication()
+                instanceof JwtAuthenticationToken authentication) {
+            var token = tokenProvider.createToken(authentication.getUserInfo());
+            tokenSupport.injectToken(response, token);
+        }
+    }
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/v1/ArchiveControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/ArchiveControllerV1.java
@@ -56,7 +56,7 @@ public class ArchiveControllerV1 {
     }
 
     @Deprecated
-    @Operation(summary = "이미지 업로드")
+    @Operation(summary = "[Deprecated -> /api/v2/user/profile/image/upload] 이미지 업로드")
     @PostMapping(path = "/image/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ArchiveImageUrlResponseDto> uploadImage(@RequestParam("image") MultipartFile imageFile) {
         imageService.verifyImageFile(imageFile);

--- a/archive-web/src/main/java/site/archive/web/api/v1/RegisterControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/RegisterControllerV1.java
@@ -2,24 +2,19 @@ package site.archive.web.api.v1;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import site.archive.domain.user.UserInfo;
 import site.archive.dto.v1.auth.PasswordRegisterCommand;
 import site.archive.dto.v1.user.OAuthRegisterRequestDto;
 import site.archive.infra.user.oauth.OAuthUserService;
 import site.archive.service.user.UserRegisterService;
-import site.archive.web.config.security.token.HttpAuthTokenSupport;
-import site.archive.web.config.security.token.TokenProvider;
-
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
+import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -30,38 +25,26 @@ public class RegisterControllerV1 {
     private final OAuthUserService oAuthUserService;
     private final PasswordEncoder encoder;
 
-    // JWT token provider
-    private final TokenProvider tokenProvider;
-    private final HttpAuthTokenSupport tokenSupport;
-
     @Operation(summary = "[NoAuth] 패스워드 유저 회원가입")
     @PostMapping("/register")
-    public ResponseEntity<Void> registerUser(@RequestBody @Valid PasswordRegisterCommand command) {
+    public ResponseEntity<Void> registerUser(@Validated @RequestBody PasswordRegisterCommand command) {
         encryptPassword(command);
-        userRegisterService.registerUser(command);
+        var userInfo = userRegisterService.registerUser(command).convertToUserInfo();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "[NoAuth] 소셜 로그인 유저 회원가입 및 로그인")
     @PostMapping("/social")
-    public ResponseEntity<Void> registerOrLoginSocialUser(HttpServletResponse httpServletResponse,
-                                                          @Validated @RequestBody OAuthRegisterRequestDto oAuthRegisterRequestDto) {
+    public ResponseEntity<Void> registerOrLoginSocialUser(@Validated @RequestBody OAuthRegisterRequestDto oAuthRegisterRequestDto) {
         var oAuthRegisterInfo = oAuthUserService.getOAuthRegisterInfo(oAuthRegisterRequestDto);
         var userInfo = userRegisterService.getOrRegisterUserReturnInfo(oAuthRegisterInfo);
-        injectJwtToken(httpServletResponse, userInfo);
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
         return ResponseEntity.ok().build();
-
-    }
-
-    private void injectJwtToken(HttpServletResponse httpServletResponse, UserInfo userInfo) {
-        var successToken = tokenProvider.createToken(userInfo);
-        tokenSupport.injectToken(httpServletResponse, successToken);
-        httpServletResponse.setStatus(HttpStatus.OK.value());
     }
 
     private void encryptPassword(PasswordRegisterCommand command) {
         command.setPassword(encoder.encode(command.getPassword()));
     }
-
 
 }

--- a/archive-web/src/main/java/site/archive/web/api/v1/UserControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/UserControllerV1.java
@@ -48,14 +48,14 @@ public class UserControllerV1 {
     }
 
     @Deprecated
-    @Operation(summary = "자기 정보 조회")
+    @Operation(summary = "[Deprecated -> /api/v2/user/profile] 자기 정보 조회")
     @GetMapping("/info")
     public ResponseEntity<UserInfo> getUserInfo(@RequestUser UserInfo user) {
         return ResponseEntity.ok(user);
     }
 
     @Deprecated
-    @Operation(summary = "[NoAuth] 이메일 중복 검사")
+    @Operation(summary = "[Deprecated -> /api/v2/user/duplicate/email] 이메일 중복 검사")
     @GetMapping("/email/{email}")
     public ResponseEntity<EmailDuplicateResponseDto> checkDuplicatedEmail(@PathVariable String email) {
         var emailDuplicateResponseDto = new EmailDuplicateResponseDto(userService.existsEmail(email));
@@ -71,7 +71,7 @@ public class UserControllerV1 {
     }
 
     @Deprecated
-    @Operation(summary = "비밀번호 초기화 - 새로운 비밀번호 설정")
+    @Operation(summary = "[Deprecated -> /api/v2/auth/password/reset] 비밀번호 초기화 - 새로운 비밀번호 설정")
     @PostMapping("/password/reset")
     public ResponseEntity<Void> resetPassword(@Validated @RequestBody UserPasswordResetRequestDto userPasswordResetRequestDto) {
         userAuthService.resetPassword(userPasswordResetRequestDto);

--- a/archive-web/src/main/java/site/archive/web/api/v1/UserControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/UserControllerV1.java
@@ -47,6 +47,7 @@ public class UserControllerV1 {
         return ResponseEntity.ok().build();
     }
 
+    @Deprecated
     @Operation(summary = "자기 정보 조회")
     @GetMapping("/info")
     public ResponseEntity<UserInfo> getUserInfo(@RequestUser UserInfo user) {

--- a/archive-web/src/main/java/site/archive/web/api/v1/UserControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/UserControllerV1.java
@@ -54,6 +54,7 @@ public class UserControllerV1 {
         return ResponseEntity.ok(user);
     }
 
+    @Deprecated
     @Operation(summary = "[NoAuth] 이메일 중복 검사")
     @GetMapping("/email/{email}")
     public ResponseEntity<EmailDuplicateResponseDto> checkDuplicatedEmail(@PathVariable String email) {

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserControllerV2.java
@@ -1,0 +1,48 @@
+package site.archive.web.api.v2;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v1.archive.EmailDuplicateResponseDto;
+import site.archive.dto.v2.NicknameDuplicateResponseDto;
+import site.archive.dto.v2.UserNicknameUpdateRequest;
+import site.archive.service.user.UserService;
+import site.archive.web.api.resolver.annotation.RequestUser;
+
+@RestController
+@RequestMapping("/api/v2/user")
+@RequiredArgsConstructor
+public class UserControllerV2 {
+
+    private final UserService userService;
+
+    @Operation(summary = "[NoAuth] 이메일 중복 검사")
+    @GetMapping("/duplicate/email")
+    public ResponseEntity<EmailDuplicateResponseDto> checkDuplicatedEmail(@RequestParam String email) {
+        var emailDuplicateResponseDto = new EmailDuplicateResponseDto(userService.existsEmail(email));
+        return ResponseEntity.ok(emailDuplicateResponseDto);
+    }
+
+    @Operation(summary = "[NoAuth] 닉네임 중복 검사")
+    @GetMapping("/duplicate/nickname")
+    public ResponseEntity<NicknameDuplicateResponseDto> checkDuplicatedNickname(@RequestParam String nickname) {
+        var nicknameDuplicateResponseDto = new NicknameDuplicateResponseDto(userService.existsNickname(nickname));
+        return ResponseEntity.ok(nicknameDuplicateResponseDto);
+    }
+
+    @Operation(summary = "프로필 닉네임 수정 (업데이트)")
+    @PutMapping("/nickname")
+    public ResponseEntity<Void> updateProfileNickname(@RequestUser UserInfo user,
+                                                      @RequestBody UserNicknameUpdateRequest request) {
+        userService.updateUserNickname(user.getUserId(), request.nickname());
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserControllerV2.java
@@ -25,14 +25,14 @@ public class UserControllerV2 {
 
     @Operation(summary = "[NoAuth] 이메일 중복 검사")
     @GetMapping("/duplicate/email")
-    public ResponseEntity<EmailDuplicateResponseDto> checkDuplicatedEmail(@RequestParam String email) {
+    public ResponseEntity<EmailDuplicateResponseDto> checkDuplicatedEmail(@RequestParam(value = "value") String email) {
         var emailDuplicateResponseDto = new EmailDuplicateResponseDto(userService.existsEmail(email));
         return ResponseEntity.ok(emailDuplicateResponseDto);
     }
 
     @Operation(summary = "[NoAuth] 닉네임 중복 검사")
     @GetMapping("/duplicate/nickname")
-    public ResponseEntity<NicknameDuplicateResponseDto> checkDuplicatedNickname(@RequestParam String nickname) {
+    public ResponseEntity<NicknameDuplicateResponseDto> checkDuplicatedNickname(@RequestParam(value = "value") String nickname) {
         var nicknameDuplicateResponseDto = new NicknameDuplicateResponseDto(userService.existsNickname(nickname));
         return ResponseEntity.ok(nicknameDuplicateResponseDto);
     }

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserProfileControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserProfileControllerV2.java
@@ -5,12 +5,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.archive.domain.user.UserInfo;
+import site.archive.dto.v1.user.BaseUserDto;
 import site.archive.service.archive.ArchiveImageService;
 import site.archive.service.user.UserProfileImageService;
 import site.archive.service.user.UserService;
@@ -26,6 +28,12 @@ public class UserProfileControllerV2 {
     private final UserService userService;
     private final UserProfileImageService userProfileImageService;
     private final ArchiveImageService imageService;
+
+    @Operation(summary = "프로필 정보 조회")
+    @GetMapping
+    public ResponseEntity<BaseUserDto> getUserProfileInfo(@RequestUser UserInfo user) {
+        return ResponseEntity.ok(userService.findSpecificUserById(user.getUserId()));
+    }
 
     @Operation(summary = "프로필 이미지 업로드 및 업데이트")
     @PostMapping(path = "/image/upload",

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserProfileControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserProfileControllerV2.java
@@ -7,15 +7,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.archive.domain.user.UserInfo;
 import site.archive.dto.v1.user.BaseUserDto;
-import site.archive.dto.v2.UserNicknameUpdateRequest;
 import site.archive.service.archive.ArchiveImageService;
 import site.archive.service.user.UserProfileImageService;
 import site.archive.service.user.UserService;
@@ -36,14 +33,6 @@ public class UserProfileControllerV2 {
     @GetMapping
     public ResponseEntity<BaseUserDto> getUserProfileInfo(@RequestUser UserInfo user) {
         return ResponseEntity.ok(userService.findSpecificUserById(user.getUserId()));
-    }
-
-    @Operation(summary = "프로필 닉네임 수정 (업데이트)")
-    @PutMapping("/nickname")
-    public ResponseEntity<Void> updateProfileNickname(@RequestUser UserInfo user,
-                                                      @RequestBody UserNicknameUpdateRequest request) {
-        userService.updateUserNickname(user.getUserId(), request.nickname());
-        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "프로필 이미지 업로드 및 업데이트")

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserProfileControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserProfileControllerV2.java
@@ -7,12 +7,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.archive.domain.user.UserInfo;
 import site.archive.dto.v1.user.BaseUserDto;
+import site.archive.dto.v2.UserNicknameUpdateRequest;
 import site.archive.service.archive.ArchiveImageService;
 import site.archive.service.user.UserProfileImageService;
 import site.archive.service.user.UserService;
@@ -33,6 +36,14 @@ public class UserProfileControllerV2 {
     @GetMapping
     public ResponseEntity<BaseUserDto> getUserProfileInfo(@RequestUser UserInfo user) {
         return ResponseEntity.ok(userService.findSpecificUserById(user.getUserId()));
+    }
+
+    @Operation(summary = "프로필 닉네임 수정 (업데이트)")
+    @PutMapping("/nickname")
+    public ResponseEntity<Void> updateProfileNickname(@RequestUser UserInfo user,
+                                                      @RequestBody UserNicknameUpdateRequest request) {
+        userService.updateUserNickname(user.getUserId(), request.nickname());
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "프로필 이미지 업로드 및 업데이트")

--- a/archive-web/src/main/java/site/archive/web/config/WebConfigurer.java
+++ b/archive-web/src/main/java/site/archive/web/config/WebConfigurer.java
@@ -1,19 +1,28 @@
 package site.archive.web.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import site.archive.web.api.converter.StringToSortTypeConverter;
+import site.archive.web.api.interceptor.InjectTokenInterceptor;
 import site.archive.web.api.resolver.ArchivePageableArgumentResolver;
 import site.archive.web.api.resolver.UserArgumentResolver;
+import site.archive.web.config.security.token.HttpAuthTokenSupport;
+import site.archive.web.config.security.token.TokenProvider;
 
 import java.util.List;
 
 @EnableWebMvc
 @Configuration
+@RequiredArgsConstructor
 public class WebConfigurer implements WebMvcConfigurer {
+
+    private final TokenProvider tokenProvider;
+    private final HttpAuthTokenSupport tokenSupport;
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
@@ -24,6 +33,12 @@ public class WebConfigurer implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new UserArgumentResolver());
         resolvers.add(new ArchivePageableArgumentResolver());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new InjectTokenInterceptor(tokenProvider, tokenSupport))
+                .addPathPatterns("/api/v1/auth/**");
     }
 
 }

--- a/archive-web/src/main/java/site/archive/web/config/security/SecurityConfig.java
+++ b/archive-web/src/main/java/site/archive/web/config/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                    .headers().frameOptions().sameOrigin().and()
                    .authorizeRequests()
                        .antMatchers("/api/v1/**").permitAll()
+                       .antMatchers("/api/v2/user/duplicate/**").permitAll()
                        .antMatchers("/login/**").permitAll()
                        .antMatchers(HttpMethod.GET, "/exception/**").permitAll()
                        .anyRequest().authenticated().and()


### PR DESCRIPTION
- 유저 닉네임 필드 추가
  - 닉네임 중복검사 API
  - 닉네임 업데이트 API
 
- 프로필 관련 API Controller 분기 및 리팩터링
  - 이메일 중복검사 API를 닉네임 중복검사 API와 통일성 있게 구현 (Path variable을 사용한 방식에서 Query parameter 형태로 수정)
  - 프로필 업데이트 조회 v2 API 추가 (닉네임, 프로필 이미지 추가)

- Deprecated annotation에 변경된 endpoint 정보 추가

- 기존 유저들은 Nickname이 null. 
  - 프로필 조회 시 nickname이 null인 경우, mail id를 반환
