### PR TITLE
feat: password register return token

### DIFF
--- a/archive-common/src/main/java/site/archive/common/exception/ExceptionCode.java
+++ b/archive-common/src/main/java/site/archive/common/exception/ExceptionCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionCode {
 
     // Global
-    NO_VALUE(HttpStatus.BAD_REQUEST, "Global001", "필요한 값이 없거나 문제가 없습니다."),
+    NO_VALUE(HttpStatus.BAD_REQUEST, "Global001", "필요한 값이 없거나 전달된 값에 문제가 있습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Global002", "Invalid Input Value"),
     TYPE_MISMATCH_VALUE(HttpStatus.BAD_REQUEST, "Global003", "타입(enum)이 일치하지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Global004", "Invalid Input Value"),

--- a/archive-web/src/main/java/site/archive/web/api/interceptor/InjectTokenInterceptor.java
+++ b/archive-web/src/main/java/site/archive/web/api/interceptor/InjectTokenInterceptor.java
@@ -1,0 +1,32 @@
+package site.archive.web.api.interceptor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import site.archive.web.config.security.token.HttpAuthTokenSupport;
+import site.archive.web.config.security.token.TokenProvider;
+import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+public class InjectTokenInterceptor implements HandlerInterceptor {
+
+    private final TokenProvider tokenProvider;
+    private final HttpAuthTokenSupport tokenSupport;
+
+    @Override
+    public void postHandle(HttpServletRequest request,
+                           HttpServletResponse response,
+                           Object handler,
+                           ModelAndView modelAndView) {
+        if (SecurityContextHolder.getContext().getAuthentication()
+                instanceof JwtAuthenticationToken authentication) {
+            var token = tokenProvider.createToken(authentication.getUserInfo());
+            tokenSupport.injectToken(response, token);
+        }
+    }
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/v1/RegisterControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/RegisterControllerV1.java
@@ -2,24 +2,19 @@ package site.archive.web.api.v1;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import site.archive.domain.user.UserInfo;
 import site.archive.dto.v1.auth.PasswordRegisterCommand;
 import site.archive.dto.v1.user.OAuthRegisterRequestDto;
 import site.archive.infra.user.oauth.OAuthUserService;
 import site.archive.service.user.UserRegisterService;
-import site.archive.web.config.security.token.HttpAuthTokenSupport;
-import site.archive.web.config.security.token.TokenProvider;
-
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
+import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -30,38 +25,26 @@ public class RegisterControllerV1 {
     private final OAuthUserService oAuthUserService;
     private final PasswordEncoder encoder;
 
-    // JWT token provider
-    private final TokenProvider tokenProvider;
-    private final HttpAuthTokenSupport tokenSupport;
-
     @Operation(summary = "[NoAuth] 패스워드 유저 회원가입")
     @PostMapping("/register")
-    public ResponseEntity<Void> registerUser(@RequestBody @Valid PasswordRegisterCommand command) {
+    public ResponseEntity<Void> registerUser(@Validated @RequestBody PasswordRegisterCommand command) {
         encryptPassword(command);
-        userRegisterService.registerUser(command);
+        var userInfo = userRegisterService.registerUser(command).convertToUserInfo();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "[NoAuth] 소셜 로그인 유저 회원가입 및 로그인")
     @PostMapping("/social")
-    public ResponseEntity<Void> registerOrLoginSocialUser(HttpServletResponse httpServletResponse,
-                                                          @Validated @RequestBody OAuthRegisterRequestDto oAuthRegisterRequestDto) {
+    public ResponseEntity<Void> registerOrLoginSocialUser(@Validated @RequestBody OAuthRegisterRequestDto oAuthRegisterRequestDto) {
         var oAuthRegisterInfo = oAuthUserService.getOAuthRegisterInfo(oAuthRegisterRequestDto);
         var userInfo = userRegisterService.getOrRegisterUserReturnInfo(oAuthRegisterInfo);
-        injectJwtToken(httpServletResponse, userInfo);
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
         return ResponseEntity.ok().build();
-
-    }
-
-    private void injectJwtToken(HttpServletResponse httpServletResponse, UserInfo userInfo) {
-        var successToken = tokenProvider.createToken(userInfo);
-        tokenSupport.injectToken(httpServletResponse, successToken);
-        httpServletResponse.setStatus(HttpStatus.OK.value());
     }
 
     private void encryptPassword(PasswordRegisterCommand command) {
         command.setPassword(encoder.encode(command.getPassword()));
     }
-
 
 }

--- a/archive-web/src/main/java/site/archive/web/config/WebConfigurer.java
+++ b/archive-web/src/main/java/site/archive/web/config/WebConfigurer.java
@@ -1,19 +1,28 @@
 package site.archive.web.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import site.archive.web.api.converter.StringToSortTypeConverter;
+import site.archive.web.api.interceptor.InjectTokenInterceptor;
 import site.archive.web.api.resolver.ArchivePageableArgumentResolver;
 import site.archive.web.api.resolver.UserArgumentResolver;
+import site.archive.web.config.security.token.HttpAuthTokenSupport;
+import site.archive.web.config.security.token.TokenProvider;
 
 import java.util.List;
 
 @EnableWebMvc
 @Configuration
+@RequiredArgsConstructor
 public class WebConfigurer implements WebMvcConfigurer {
+
+    private final TokenProvider tokenProvider;
+    private final HttpAuthTokenSupport tokenSupport;
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
@@ -24,6 +33,12 @@ public class WebConfigurer implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new UserArgumentResolver());
         resolvers.add(new ArchivePageableArgumentResolver());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new InjectTokenInterceptor(tokenProvider, tokenSupport))
+                .addPathPatterns("/api/v1/auth/**");
     }
 
 }


### PR DESCRIPTION
Register endpoints에서 바로 로그인처리를 하기 위해 JWT token을 header에 넣어 반환하도록 수정
- 공용 로직이며 추후 다른 곳에서도 쉽게 사용할 수 있도록 interceptor 사용

영향 endpoints
- `{{base_url}}/api/v1/auth/register`
- `{{base_url}}/api/v1/auth/social`

