### PR TITLE
fix: kakao oauth login error

### DIFF
--- a/archive-application/src/main/java/site/archive/dto/v1/user/OAuthRegisterRequestDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v1/user/OAuthRegisterRequestDto.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
 
 @Getter
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class OAuthRegisterRequestDto {

--- a/archive-application/src/main/java/site/archive/infra/user/oauth/OAuthUserService.java
+++ b/archive-application/src/main/java/site/archive/infra/user/oauth/OAuthUserService.java
@@ -1,6 +1,7 @@
 package site.archive.infra.user.oauth;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.stereotype.Service;
 import site.archive.dto.v1.auth.OAuthRegisterCommand;
@@ -10,6 +11,7 @@ import site.archive.infra.user.oauth.provider.OAuthProviderClient;
 import java.util.List;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class OAuthUserService {
 
@@ -23,6 +25,7 @@ public class OAuthUserService {
                                                       .orElseThrow(() ->
                                                                        new ProviderNotFoundException(
                                                                            "There is no suitable register provider client for " + provider));
+        log.debug("oauth provider access token: {}", oAuthRegisterRequestDto);
         return oAuthProviderClient.getOAuthRegisterInfo(oAuthRegisterRequestDto);
     }
 

--- a/archive-application/src/main/java/site/archive/infra/user/oauth/provider/dto/KakaoUserInfo.java
+++ b/archive-application/src/main/java/site/archive/infra/user/oauth/provider/dto/KakaoUserInfo.java
@@ -1,33 +1,36 @@
 package site.archive.infra.user.oauth.provider.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.util.Map;
 
-@RequiredArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @ToString
 public class KakaoUserInfo {
 
-    private final String id;
-    private final Map<String, String> properties;
+    private String id;
+    private Map<String, String> properties;
 
     @JsonProperty(value = "kakao_account")
-    private final KakaoAccount kakaoAccount;
+    private KakaoAccount kakaoAccount;
 
     public String getEmail() {
         return kakaoAccount.getEmail();
     }
 
-    @RequiredArgsConstructor
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Getter
     public static class KakaoAccount {
 
-        private final String email;
-        private final Map<String, String> profile;
+        private String email;
+        private Map<String, String> profile;
 
     }
 


### PR DESCRIPTION
- Kakao oauth 로그인 인증 요청 시, 생성자가 required여서 databind가 되지 않는 문제가 발생.
  - 이를 해결하기 위해 기본 생성자 및 모든 필드에 대한 생성자를 추가하고 기존 불변 필드에 대한 생성자 제거

- oauth token을 확인해 테스트할 수 있도록 Debug log 추가