### PR TITLE
feat: User register/login v2

### DIFF
--- a/archive-application/src/main/java/site/archive/dto/v1/auth/OAuthRegisterCommandV1.java
+++ b/archive-application/src/main/java/site/archive/dto/v1/auth/OAuthRegisterCommandV1.java
@@ -2,6 +2,7 @@ package site.archive.dto.v1.auth;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.archive.common.ArchiveStringUtils;
 import site.archive.domain.user.BaseUser;
 import site.archive.domain.user.OAuthProvider;
 import site.archive.domain.user.OAuthUser;
@@ -18,7 +19,12 @@ public class OAuthRegisterCommandV1 extends BasicRegisterCommandV1 {
         this.provider = provider;
     }
 
+    @Override
     public BaseUser toUserEntity() {
-        return new OAuthUser(getEmail(), UserRole.GENERAL, provider);
+        return new OAuthUser(getEmail(),
+                             UserRole.GENERAL,
+                             provider,
+                             ArchiveStringUtils.extractIdFromMail(getEmail()));
     }
+
 }

--- a/archive-application/src/main/java/site/archive/dto/v1/auth/PasswordRegisterCommandV1.java
+++ b/archive-application/src/main/java/site/archive/dto/v1/auth/PasswordRegisterCommandV1.java
@@ -4,6 +4,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import site.archive.common.ArchiveStringUtils;
 import site.archive.domain.user.BaseUser;
 import site.archive.domain.user.PasswordUser;
 import site.archive.domain.user.UserRole;
@@ -29,6 +30,10 @@ public class PasswordRegisterCommandV1 extends BasicRegisterCommandV1 {
 
     @Override
     public BaseUser toUserEntity() {
-        return new PasswordUser(getEmail(), UserRole.GENERAL, getPassword());
+        return new PasswordUser(getEmail(),
+                                UserRole.GENERAL,
+                                getPassword(),
+                                ArchiveStringUtils.extractIdFromMail(getEmail()));
     }
+
 }

--- a/archive-application/src/main/java/site/archive/dto/v2/OAuthLoginRequestDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/OAuthLoginRequestDto.java
@@ -1,0 +1,22 @@
+package site.archive.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OAuthLoginRequestDto {
+
+    @NotEmpty(message = "Oauth provider는 필수 값입니다.")
+    private String provider;
+
+    @NotEmpty(message = "Provider access token은 필수 값입니다.")
+    @JsonProperty("providerAccessToken")
+    private String token;
+
+}

--- a/archive-application/src/main/java/site/archive/dto/v2/OAuthRegisterRequestDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/OAuthRegisterRequestDto.java
@@ -1,0 +1,27 @@
+package site.archive.dto.v2;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.archive.domain.user.BaseUser;
+import site.archive.domain.user.OAuthProvider;
+import site.archive.domain.user.OAuthUser;
+import site.archive.domain.user.UserRole;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OAuthRegisterRequestDto {
+
+    private OAuthProvider provider;
+    private String email;
+    private String nickname;
+
+    public BaseUser toUserEntity() {
+        return new OAuthUser(this.email,
+                             UserRole.GENERAL,
+                             this.provider,
+                             this.nickname);
+    }
+
+}

--- a/archive-application/src/main/java/site/archive/dto/v2/OAuthUserInfoRequestDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/OAuthUserInfoRequestDto.java
@@ -1,0 +1,27 @@
+package site.archive.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class OAuthUserInfoRequestDto {
+
+    @NotEmpty(message = "Oauth provider는 필수 값입니다.")
+    private String provider;
+
+    @NotEmpty(message = "Provider access token은 필수 값입니다.")
+    @JsonProperty("providerAccessToken")
+    private String token;
+
+    @NotEmpty(message = "닉네임은 필수 값입니다.")
+    private String nickname;
+
+}

--- a/archive-application/src/main/java/site/archive/dto/v2/PasswordRegisterRequestDto.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/PasswordRegisterRequestDto.java
@@ -1,0 +1,39 @@
+package site.archive.dto.v2;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.archive.domain.user.BaseUser;
+import site.archive.domain.user.PasswordUser;
+import site.archive.domain.user.UserRole;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordRegisterRequestDto {
+
+    @NotEmpty(message = "이메일은 필수 값입니다.")
+    @Email(message = "올바른 이메일을 입력해 주세요.")
+    private String email;
+
+    @NotEmpty(message = "패스워드는 필수 값입니다.")
+    @Pattern(regexp = "(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9@$!%*#?&]{8,20}$",
+             message = "비밀번호는 영문/숫자 를 꼭 포함하여 8~20자리로 입력해 주세요.")
+    private String password;
+
+    @NotEmpty(message = "닉네임은 필수 값입니다.")
+    private String nickname;
+
+    public BaseUser toUserEntity() {
+        return new PasswordUser(this.email, UserRole.GENERAL, this.password, this.nickname);
+    }
+
+    public void updatePasswordToEncrypt(String encryptPassword) {
+        this.password = encryptPassword;
+    }
+
+}

--- a/archive-application/src/main/java/site/archive/infra/messaging/SlackService.java
+++ b/archive-application/src/main/java/site/archive/infra/messaging/SlackService.java
@@ -53,6 +53,9 @@ public class SlackService implements MessagingService {
                                                            ":email: `이메일`: %s",
                                                            baseUser.getMailAddress())))),
                                                        Blocks.section(section -> section.text(BlockCompositions.markdownText(String.format(
+                                                           ":speaking_head_in_silhouette: `닉네임`: %s",
+                                                           baseUser.getNickname())))),
+                                                       Blocks.section(section -> section.text(BlockCompositions.markdownText(String.format(
                                                            ":date: `가입시간`: %s",
                                                            baseUser.getCreatedAt()))))
                                                    )));

--- a/archive-application/src/main/java/site/archive/infra/user/oauth/OAuthUserService.java
+++ b/archive-application/src/main/java/site/archive/infra/user/oauth/OAuthUserService.java
@@ -19,14 +19,17 @@ public class OAuthUserService {
 
     public OAuthRegisterCommandV1 getOAuthRegisterInfo(OAuthRegisterRequestDtoV1 oAuthRegisterRequestDtoV1) {
         var provider = oAuthRegisterRequestDtoV1.getProvider();
-        var oAuthProviderClient = oAuthProviderClients.stream()
-                                                      .filter(client -> client.support().equals(provider))
-                                                      .findFirst()
-                                                      .orElseThrow(() ->
-                                                                       new ProviderNotFoundException(
-                                                                           "There is no suitable register provider client for " + provider));
+        var oAuthProviderClient = getOAuthProviderClient(provider);
         log.debug("oauth provider access token: {}", oAuthRegisterRequestDtoV1);
         return oAuthProviderClient.getOAuthRegisterInfo(oAuthRegisterRequestDtoV1);
+    }
+
+    private OAuthProviderClient getOAuthProviderClient(String provider) {
+        return oAuthProviderClients.stream()
+                                   .filter(client -> client.support().equals(provider))
+                                   .findFirst()
+                                   .orElseThrow(() -> new ProviderNotFoundException(
+                                       "There is no suitable register provider client for " + provider));
     }
 
 }

--- a/archive-application/src/main/java/site/archive/infra/user/oauth/OAuthUserService.java
+++ b/archive-application/src/main/java/site/archive/infra/user/oauth/OAuthUserService.java
@@ -6,6 +6,7 @@ import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.stereotype.Service;
 import site.archive.dto.v1.auth.OAuthRegisterCommandV1;
 import site.archive.dto.v1.user.OAuthRegisterRequestDtoV1;
+import site.archive.dto.v2.OAuthLoginRequestDto;
 import site.archive.dto.v2.OAuthRegisterRequestDto;
 import site.archive.dto.v2.OAuthUserInfoRequestDto;
 import site.archive.infra.user.oauth.provider.OAuthProviderClient;
@@ -32,6 +33,13 @@ public class OAuthUserService {
         var oAuthProviderClient = getOAuthProviderClient(provider);
         var email = oAuthProviderClient.getEmail(request.getToken());
         return new OAuthRegisterRequestDto(oAuthProviderClient.getProvider(), email, request.getNickname());
+    }
+
+    public String getOAuthEmail(OAuthLoginRequestDto request) {
+        log.debug("oauth provider access token: {}", request);
+        var provider = request.getProvider();
+        var oAuthProviderClient = getOAuthProviderClient(provider);
+        return oAuthProviderClient.getEmail(request.getToken());
     }
 
     private OAuthProviderClient getOAuthProviderClient(String provider) {

--- a/archive-application/src/main/java/site/archive/infra/user/oauth/OAuthUserService.java
+++ b/archive-application/src/main/java/site/archive/infra/user/oauth/OAuthUserService.java
@@ -6,6 +6,8 @@ import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.stereotype.Service;
 import site.archive.dto.v1.auth.OAuthRegisterCommandV1;
 import site.archive.dto.v1.user.OAuthRegisterRequestDtoV1;
+import site.archive.dto.v2.OAuthRegisterRequestDto;
+import site.archive.dto.v2.OAuthUserInfoRequestDto;
 import site.archive.infra.user.oauth.provider.OAuthProviderClient;
 
 import java.util.List;
@@ -17,16 +19,24 @@ public class OAuthUserService {
 
     private final List<OAuthProviderClient> oAuthProviderClients;
 
-    public OAuthRegisterCommandV1 getOAuthRegisterInfo(OAuthRegisterRequestDtoV1 oAuthRegisterRequestDtoV1) {
-        var provider = oAuthRegisterRequestDtoV1.getProvider();
+    public OAuthRegisterCommandV1 getOAuthRegisterInfo(OAuthRegisterRequestDtoV1 request) {
+        log.debug("oauth provider access token: {}", request);
+        var provider = request.getProvider();
         var oAuthProviderClient = getOAuthProviderClient(provider);
-        log.debug("oauth provider access token: {}", oAuthRegisterRequestDtoV1);
-        return oAuthProviderClient.getOAuthRegisterInfo(oAuthRegisterRequestDtoV1);
+        return oAuthProviderClient.getOAuthRegisterInfo(request.getToken());
+    }
+
+    public OAuthRegisterRequestDto getOAuthRegisterInfo(OAuthUserInfoRequestDto request) {
+        log.debug("oauth provider access token: {}", request);
+        var provider = request.getProvider();
+        var oAuthProviderClient = getOAuthProviderClient(provider);
+        var email = oAuthProviderClient.getEmail(request.getToken());
+        return new OAuthRegisterRequestDto(oAuthProviderClient.getProvider(), email, request.getNickname());
     }
 
     private OAuthProviderClient getOAuthProviderClient(String provider) {
         return oAuthProviderClients.stream()
-                                   .filter(client -> client.support().equals(provider))
+                                   .filter(client -> client.getProvider().getRegistrationId().equals(provider))
                                    .findFirst()
                                    .orElseThrow(() -> new ProviderNotFoundException(
                                        "There is no suitable register provider client for " + provider));

--- a/archive-application/src/main/java/site/archive/infra/user/oauth/provider/AppleClient.java
+++ b/archive-application/src/main/java/site/archive/infra/user/oauth/provider/AppleClient.java
@@ -16,7 +16,6 @@ import org.springframework.web.client.RestTemplate;
 import site.archive.common.exception.user.OAuthRegisterFailException;
 import site.archive.domain.user.OAuthProvider;
 import site.archive.dto.v1.auth.OAuthRegisterCommandV1;
-import site.archive.dto.v1.user.OAuthRegisterRequestDtoV1;
 import site.archive.infra.user.oauth.provider.dto.ApplePublicKeys;
 import site.archive.infra.user.oauth.provider.dto.AppleTokenPayload;
 
@@ -38,16 +37,24 @@ public class AppleClient implements OAuthProviderClient {
     private final RestTemplate restTemplate;
 
     @Override
-    public String support() {
-        return OAuthProvider.APPLE.getRegistrationId();
+    public OAuthProvider getProvider() {
+        return OAuthProvider.APPLE;
     }
 
     @Override
-    public OAuthRegisterCommandV1 getOAuthRegisterInfo(OAuthRegisterRequestDtoV1 oAuthRegisterRequestDtoV1) {
-        var jwtToken = getSignedJWT(oAuthRegisterRequestDtoV1.getToken());
+    public OAuthRegisterCommandV1 getOAuthRegisterInfo(String accessToken) {
+        var jwtToken = getSignedJWT(accessToken);
         var payload = getAppleTokenPayload(jwtToken);
         AppleTokenVerifier.verify(objectMapper, restTemplate, appleOAuthProperty, jwtToken, payload);
         return new OAuthRegisterCommandV1(payload.getEmail(), OAuthProvider.APPLE);
+    }
+
+    @Override
+    public String getEmail(String accessToken) {
+        var jwtToken = getSignedJWT(accessToken);
+        var payload = getAppleTokenPayload(jwtToken);
+        AppleTokenVerifier.verify(objectMapper, restTemplate, appleOAuthProperty, jwtToken, payload);
+        return payload.getEmail();
     }
 
     private SignedJWT getSignedJWT(final String jwtToken) {

--- a/archive-application/src/main/java/site/archive/infra/user/oauth/provider/KakaoClient.java
+++ b/archive-application/src/main/java/site/archive/infra/user/oauth/provider/KakaoClient.java
@@ -12,8 +12,6 @@ import org.springframework.web.client.RestTemplate;
 import site.archive.common.exception.user.OAuthRegisterFailException;
 import site.archive.domain.user.OAuthProvider;
 import site.archive.dto.v1.auth.OAuthRegisterCommandV1;
-import site.archive.dto.v1.user.OAuthRegisterRequestDtoV1;
-import site.archive.infra.user.oauth.provider.dto.KakaoProviderRequirements;
 import site.archive.infra.user.oauth.provider.dto.KakaoUserInfo;
 
 @Component
@@ -27,18 +25,23 @@ public class KakaoClient implements OAuthProviderClient {
     private String userInfoUrl;
 
     @Override
-    public String support() {
-        return OAuthProvider.KAKAO.getRegistrationId();
+    public OAuthProvider getProvider() {
+        return OAuthProvider.KAKAO;
     }
 
     @Override
-    public OAuthRegisterCommandV1 getOAuthRegisterInfo(OAuthRegisterRequestDtoV1 oAuthRegisterRequestDtoV1) {
-        var userEmail = getUserEmail(KakaoProviderRequirements.from(oAuthRegisterRequestDtoV1));
+    public OAuthRegisterCommandV1 getOAuthRegisterInfo(String accessToken) {
+        var userEmail = getUserEmail(accessToken);
         return new OAuthRegisterCommandV1(userEmail, OAuthProvider.KAKAO);
     }
 
-    private String getUserEmail(KakaoProviderRequirements requirements) {
-        var entity = userInfoRequestEntity(requirements.getKakaoAccessToken());
+    @Override
+    public String getEmail(String accessToken) {
+        return getUserEmail(accessToken);
+    }
+
+    private String getUserEmail(String accessToken) {
+        var entity = userInfoRequestEntity(accessToken);
         var response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, entity, KakaoUserInfo.class);
         var kakaoUserInfo = response.getBody();
 

--- a/archive-application/src/main/java/site/archive/infra/user/oauth/provider/OAuthProviderClient.java
+++ b/archive-application/src/main/java/site/archive/infra/user/oauth/provider/OAuthProviderClient.java
@@ -1,12 +1,14 @@
 package site.archive.infra.user.oauth.provider;
 
+import site.archive.domain.user.OAuthProvider;
 import site.archive.dto.v1.auth.OAuthRegisterCommandV1;
-import site.archive.dto.v1.user.OAuthRegisterRequestDtoV1;
 
 public interface OAuthProviderClient {
 
-    String support();
+    OAuthProvider getProvider();
 
-    OAuthRegisterCommandV1 getOAuthRegisterInfo(OAuthRegisterRequestDtoV1 oAuthRegisterRequestDtoV1);
+    OAuthRegisterCommandV1 getOAuthRegisterInfo(String accessToken);
+
+    String getEmail(String accessToken);
 
 }

--- a/archive-application/src/main/java/site/archive/service/user/UserRegisterServiceV1.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserRegisterServiceV1.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.archive.common.exception.common.DuplicateResourceException;
 import site.archive.domain.user.BaseUser;
+import site.archive.domain.user.PasswordUser;
 import site.archive.domain.user.UserInfo;
 import site.archive.domain.user.UserRepository;
 import site.archive.dto.v1.auth.BasicRegisterCommandV1;
@@ -50,7 +51,7 @@ public class UserRegisterServiceV1 {
             var oauthProvider = oAuthRegisterCommand.getProvider().getRegistrationId();
             messagingService.sendUserRegisterMessage(BaseUserDtoV1.from(user), oauthProvider);
         } else {
-            messagingService.sendUserRegisterMessage(BaseUserDtoV1.from(user), "Id/Password");
+            messagingService.sendUserRegisterMessage(BaseUserDtoV1.from(user), PasswordUser.PASSWORD_TYPE);
         }
     }
 

--- a/archive-application/src/main/java/site/archive/service/user/UserRegisterServiceV2.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserRegisterServiceV2.java
@@ -22,9 +22,9 @@ public class UserRegisterServiceV2 {
     private final UserRepository userRepository;
     private final MessagingService messagingService;
 
-    public BaseUser registerUser(PasswordRegisterRequestDto registerCommand) {
+    public BaseUser registerUser(PasswordRegisterRequestDto registerRequest) {
         try {
-            var user = userRepository.save(registerCommand.toUserEntity());
+            var user = userRepository.save(registerRequest.toUserEntity());
             messagingService.sendUserRegisterMessage(BaseUserDtoV1.from(user), PasswordUser.PASSWORD_TYPE);
             return user;
         } catch (DataIntegrityViolationException e) {

--- a/archive-application/src/main/java/site/archive/service/user/UserRegisterServiceV2.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserRegisterServiceV2.java
@@ -6,10 +6,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.archive.common.exception.common.DuplicateResourceException;
-import site.archive.domain.user.BaseUser;
 import site.archive.domain.user.PasswordUser;
+import site.archive.domain.user.UserInfo;
 import site.archive.domain.user.UserRepository;
 import site.archive.dto.v1.user.BaseUserDtoV1;
+import site.archive.dto.v2.OAuthRegisterRequestDto;
 import site.archive.dto.v2.PasswordRegisterRequestDto;
 import site.archive.service.message.MessagingService;
 
@@ -22,11 +23,22 @@ public class UserRegisterServiceV2 {
     private final UserRepository userRepository;
     private final MessagingService messagingService;
 
-    public BaseUser registerUser(PasswordRegisterRequestDto registerRequest) {
+    public UserInfo registerUser(PasswordRegisterRequestDto registerRequest) {
         try {
             var user = userRepository.save(registerRequest.toUserEntity());
             messagingService.sendUserRegisterMessage(BaseUserDtoV1.from(user), PasswordUser.PASSWORD_TYPE);
-            return user;
+            return user.convertToUserInfo();
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateResourceException("이메일 또는 닉네임이 중복되었습니다. 중복을 다시 확인해주세요.");
+        }
+    }
+
+    public UserInfo registerUser(OAuthRegisterRequestDto registerCommand) {
+        try {
+            var user = userRepository.save(registerCommand.toUserEntity());
+            var oauthProvider = registerCommand.getProvider().getRegistrationId();
+            messagingService.sendUserRegisterMessage(BaseUserDtoV1.from(user), oauthProvider);
+            return user.convertToUserInfo();
         } catch (DataIntegrityViolationException e) {
             throw new DuplicateResourceException("이메일 또는 닉네임이 중복되었습니다. 중복을 다시 확인해주세요.");
         }

--- a/archive-application/src/main/java/site/archive/service/user/UserRegisterServiceV2.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserRegisterServiceV2.java
@@ -1,0 +1,35 @@
+package site.archive.service.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.archive.common.exception.common.DuplicateResourceException;
+import site.archive.domain.user.BaseUser;
+import site.archive.domain.user.PasswordUser;
+import site.archive.domain.user.UserRepository;
+import site.archive.dto.v1.user.BaseUserDtoV1;
+import site.archive.dto.v2.PasswordRegisterRequestDto;
+import site.archive.service.message.MessagingService;
+
+@Service
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+public class UserRegisterServiceV2 {
+
+    private final UserRepository userRepository;
+    private final MessagingService messagingService;
+
+    public BaseUser registerUser(PasswordRegisterRequestDto registerCommand) {
+        try {
+            var user = userRepository.save(registerCommand.toUserEntity());
+            messagingService.sendUserRegisterMessage(BaseUserDtoV1.from(user), PasswordUser.PASSWORD_TYPE);
+            return user;
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateResourceException("이메일 또는 닉네임이 중복되었습니다. 중복을 다시 확인해주세요.");
+        }
+    }
+
+}

--- a/archive-application/src/main/java/site/archive/service/user/UserService.java
+++ b/archive-application/src/main/java/site/archive/service/user/UserService.java
@@ -6,8 +6,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.archive.common.exception.common.DuplicateFieldValueException;
 import site.archive.common.exception.common.ResourceNotFoundException;
-import site.archive.domain.user.OAuthUserRepository;
-import site.archive.domain.user.PasswordUserRepository;
 import site.archive.domain.user.UserRepository;
 import site.archive.dto.v1.user.BaseUserDtoV1;
 import site.archive.dto.v1.user.SpecificUserDtoV1;
@@ -19,13 +17,17 @@ import site.archive.dto.v1.user.SpecificUserDtoV1;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final PasswordUserRepository passwordUserRepository;
-    private final OAuthUserRepository oAuthUserRepository;
 
     public BaseUserDtoV1 findUserById(long userId) {
         return userRepository.findById(userId)
                              .map(BaseUserDtoV1::from)
                              .orElseThrow(() -> new ResourceNotFoundException("아이디에 해당하는 유저가 존재하지 않습니다."));
+    }
+
+    public BaseUserDtoV1 findUserByEmail(String email) {
+        return userRepository.findByMailAddress(email)
+                             .map(BaseUserDtoV1::from)
+                             .orElseThrow(() -> new ResourceNotFoundException("가입되지 않은 Email 입니다."));
     }
 
     public SpecificUserDtoV1 findSpecificUserById(long userId) {

--- a/archive-application/src/test/java/site/archive/infra/user/oauth/OAuthUserServiceTest.java
+++ b/archive-application/src/test/java/site/archive/infra/user/oauth/OAuthUserServiceTest.java
@@ -2,6 +2,7 @@ package site.archive.infra.user.oauth;
 
 import org.junit.Test;
 import org.springframework.security.authentication.ProviderNotFoundException;
+import site.archive.domain.user.OAuthProvider;
 import site.archive.dto.v1.user.OAuthRegisterRequestDtoV1;
 import site.archive.infra.user.oauth.provider.AppleClient;
 import site.archive.infra.user.oauth.provider.KakaoClient;
@@ -37,7 +38,7 @@ class OAuthUserServiceTest {
         var oAuthUserService = new OAuthUserService(providerClients);
 
         // mocking
-        when(appleClient.support()).thenReturn("apple");
+        when(appleClient.getProvider()).thenReturn(OAuthProvider.APPLE);
         when(appleClient.getOAuthRegisterInfo(any())).thenReturn(null);
 
         // when & then

--- a/archive-application/src/test/java/site/archive/infra/user/oauth/provider/KakaoClientTest.java
+++ b/archive-application/src/test/java/site/archive/infra/user/oauth/provider/KakaoClientTest.java
@@ -35,13 +35,13 @@ class KakaoClientTest {
         var kakaoUserInfoResponse = new ResponseEntity<>(kakaoUserInfo, HttpStatus.OK);
 
         var kakaoClient = new KakaoClient(restTemplate);
-        var oAuthRegisterDto = new OAuthRegisterRequestDtoV1(kakaoClient.support(), "token");
+        var oAuthRegisterDto = new OAuthRegisterRequestDtoV1(kakaoClient.getProvider().getRegistrationId(), "token");
 
         given(restTemplate.exchange(any(), any(), any(), eq(KakaoUserInfo.class), any(Object.class)))
             .willReturn(kakaoUserInfoResponse);
 
         // when
-        var kakaoRegisterCommand = kakaoClient.getOAuthRegisterInfo(oAuthRegisterDto);
+        var kakaoRegisterCommand = kakaoClient.getOAuthRegisterInfo(oAuthRegisterDto.getToken());
 
         // then
         assertThat(kakaoRegisterCommand.getProvider()).isEqualTo(OAuthProvider.KAKAO);
@@ -55,14 +55,14 @@ class KakaoClientTest {
         var kakaoUserInfoUnauthorizedResponse = new ResponseEntity<>(kakaoUserInfo, HttpStatus.UNAUTHORIZED);
 
         var kakaoClient = new KakaoClient(restTemplate);
-        var oAuthRegisterDto = new OAuthRegisterRequestDtoV1(kakaoClient.support(), "token");
+        var oAuthRegisterDto = new OAuthRegisterRequestDtoV1(kakaoClient.getProvider().getRegistrationId(), "token");
 
         given(restTemplate.exchange(any(), any(), any(), eq(KakaoUserInfo.class), any(Object.class)))
             .willReturn(kakaoUserInfoUnauthorizedResponse);
 
         // when & then
         var exception = assertThrows(OAuthRegisterFailException.class,
-                                     () -> kakaoClient.getOAuthRegisterInfo(oAuthRegisterDto));
+                                     () -> kakaoClient.getOAuthRegisterInfo(oAuthRegisterDto.getToken()));
         assertThat(exception.getMessage()).contains(OAuthProvider.KAKAO.getRegistrationId(),
                                                     "UserInfoUrl Response error");
     }

--- a/archive-common/src/main/java/site/archive/common/ArchiveStringUtils.java
+++ b/archive-common/src/main/java/site/archive/common/ArchiveStringUtils.java
@@ -1,0 +1,14 @@
+package site.archive.common;
+
+public class ArchiveStringUtils {
+
+    private static final Character MAIL_AT = '@';
+
+    private ArchiveStringUtils() {
+    }
+
+    public static String extractIdFromMail(final String mailAddress) {
+        return mailAddress.substring(0, mailAddress.indexOf(MAIL_AT));
+    }
+
+}

--- a/archive-common/src/test/java/site/archive/common/ArchiveStringUtilsTest.java
+++ b/archive-common/src/test/java/site/archive/common/ArchiveStringUtilsTest.java
@@ -1,0 +1,20 @@
+package site.archive.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArchiveStringUtilsTest {
+
+    @Test
+    void extractIdFromMailTest() {
+        // given
+        var mail1 = "bb@bb.com";
+        var mail2 = "b1b2@naver.com";
+
+        // when & then
+        assertThat(ArchiveStringUtils.extractIdFromMail(mail1)).isEqualTo("bb");
+        assertThat(ArchiveStringUtils.extractIdFromMail(mail2)).isEqualTo("b1b2");
+    }
+
+}

--- a/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import site.archive.common.ArchiveStringUtils;
 import site.archive.domain.common.BaseTimeEntity;
 
 import javax.persistence.Column;
@@ -64,7 +65,7 @@ public class BaseUser extends BaseTimeEntity {
     }
 
     public String getNickname() {
-        return nickname != null ? nickname : mailAddress.substring(0, mailAddress.indexOf('@'));
+        return nickname != null ? nickname : ArchiveStringUtils.extractIdFromMail(mailAddress);
     }
 
     public String getProfileImage() {

--- a/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/BaseUser.java
@@ -60,6 +60,12 @@ public class BaseUser extends BaseTimeEntity {
         this.mailAddress = mailAddress;
     }
 
+    protected BaseUser(String mailAddress, UserRole role, String nickname) {
+        this.role = role;
+        this.mailAddress = mailAddress;
+        this.nickname = nickname;
+    }
+
     public UserInfo convertToUserInfo() {
         return new UserInfo(mailAddress, role, id);
     }

--- a/archive-domain/src/main/java/site/archive/domain/user/OAuthUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/OAuthUser.java
@@ -23,8 +23,8 @@ public class OAuthUser extends BaseUser {
     @Enumerated(EnumType.STRING)
     private OAuthProvider oAuthProvider;
 
-    public OAuthUser(String mailAddress, UserRole role, OAuthProvider provider) {
-        super(mailAddress, role);
+    public OAuthUser(String mailAddress, UserRole role, OAuthProvider provider, String nickname) {
+        super(mailAddress, role, nickname);
         this.oAuthProvider = provider;
     }
 

--- a/archive-domain/src/main/java/site/archive/domain/user/PasswordUser.java
+++ b/archive-domain/src/main/java/site/archive/domain/user/PasswordUser.java
@@ -25,8 +25,8 @@ public class PasswordUser extends BaseUser {
     @Column(name = "is_temporary_password", columnDefinition = "boolean default false")
     private Boolean isTemporaryPassword;
 
-    public PasswordUser(String mailAddress, UserRole role, String password) {
-        super(mailAddress, role);
+    public PasswordUser(String mailAddress, UserRole role, String password, String nickname) {
+        super(mailAddress, role, nickname);
         this.password = password;
     }
 

--- a/archive-web/src/main/java/site/archive/web/api/v1/RegisterControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/RegisterControllerV1.java
@@ -26,7 +26,7 @@ public class RegisterControllerV1 {
     private final PasswordEncoder encoder;
 
     @Deprecated
-    @Operation(summary = "[NoAuth] 패스워드 유저 회원가입")
+    @Operation(summary = "[Deprecated -> /api/v2/auth/register] 패스워드 유저 회원가입")
     @PostMapping("/register")
     public ResponseEntity<Void> registerUser(@Validated @RequestBody PasswordRegisterCommandV1 command) {
         command.setPassword(encoder.encode(command.getPassword()));
@@ -36,7 +36,7 @@ public class RegisterControllerV1 {
     }
 
     @Deprecated
-    @Operation(summary = "[NoAuth] 소셜 로그인 유저 회원가입 및 로그인")
+    @Operation(summary = "[Deprecated -> /api/v2/auth/register/social, login/social] 소셜 로그인 유저 회원가입 및 로그인")
     @PostMapping("/social")
     public ResponseEntity<Void> registerOrLoginSocialUser(@Validated @RequestBody OAuthRegisterRequestDtoV1 oAuthRegisterRequestDtoV1) {
         var oAuthRegisterInfo = oAuthUserService.getOAuthRegisterInfo(oAuthRegisterRequestDtoV1);

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
@@ -10,12 +10,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import site.archive.domain.user.UserInfo;
 import site.archive.dto.v1.user.UserPasswordResetRequestDtoV1;
+import site.archive.dto.v2.OAuthLoginRequestDto;
 import site.archive.dto.v2.OAuthUserInfoRequestDto;
 import site.archive.dto.v2.PasswordRegisterRequestDto;
 import site.archive.infra.user.oauth.OAuthUserService;
 import site.archive.service.user.UserAuthService;
 import site.archive.service.user.UserRegisterServiceV2;
+import site.archive.service.user.UserService;
 import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
 
 @RestController
@@ -23,6 +26,7 @@ import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
 @RequiredArgsConstructor
 public class UserAuthControllerV2 {
 
+    private final UserService userService;
     private final UserAuthService userAuthService;
     private final UserRegisterServiceV2 userRegisterService;
     private final OAuthUserService oAuthUserService;
@@ -49,6 +53,16 @@ public class UserAuthControllerV2 {
     public ResponseEntity<Void> registerSocialUser(@Validated @RequestBody OAuthUserInfoRequestDto oAuthUserInfoRequest) {
         var oAuthRegisterRequest = oAuthUserService.getOAuthRegisterInfo(oAuthUserInfoRequest);
         var userInfo = userRegisterService.registerUser(oAuthRegisterRequest);
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "[NoAuth] 소셜 유저 로그인")
+    @PostMapping("/login/social")
+    public ResponseEntity<Void> loginSocialUser(@Validated @RequestBody OAuthLoginRequestDto oAuthLoginRequestDto) {
+        var oAuthEmail = oAuthUserService.getOAuthEmail(oAuthLoginRequestDto);
+        var user = userService.findUserByEmail(oAuthEmail);
+        var userInfo = new UserInfo(user.getMailAddress(), user.getUserRole(), user.getUserId());
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
         return ResponseEntity.ok().build();
     }

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.archive.dto.v1.user.UserPasswordResetRequestDtoV1;
+import site.archive.dto.v2.OAuthUserInfoRequestDto;
 import site.archive.dto.v2.PasswordRegisterRequestDto;
 import site.archive.infra.user.oauth.OAuthUserService;
 import site.archive.service.user.UserAuthService;
@@ -38,7 +39,16 @@ public class UserAuthControllerV2 {
     @PostMapping("/register")
     public ResponseEntity<Void> registerPasswordUser(@Validated @RequestBody PasswordRegisterRequestDto passwordRegisterRequest) {
         passwordRegisterRequest.updatePasswordToEncrypt(encoder.encode(passwordRegisterRequest.getPassword()));
-        var userInfo = userRegisterService.registerUser(passwordRegisterRequest).convertToUserInfo();
+        var userInfo = userRegisterService.registerUser(passwordRegisterRequest);
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "[NoAuth] 소셜 유저 회원가입")
+    @PostMapping("/register/social")
+    public ResponseEntity<Void> registerSocialUser(@Validated @RequestBody OAuthUserInfoRequestDto oAuthUserInfoRequest) {
+        var oAuthRegisterRequest = oAuthUserService.getOAuthRegisterInfo(oAuthUserInfoRequest);
+        var userInfo = userRegisterService.registerUser(oAuthRegisterRequest);
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
         return ResponseEntity.ok().build();
     }

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
@@ -36,9 +36,9 @@ public class UserAuthControllerV2 {
 
     @Operation(summary = "[NoAuth] 패스워드 유저 회원가입")
     @PostMapping("/register")
-    public ResponseEntity<Void> registerPasswordUser(@Validated @RequestBody PasswordRegisterRequestDto registerRequest) {
-        registerRequest.updatePasswordToEncrypt(encoder.encode(registerRequest.getPassword()));
-        var userInfo = userRegisterService.registerUser(registerRequest).convertToUserInfo();
+    public ResponseEntity<Void> registerPasswordUser(@Validated @RequestBody PasswordRegisterRequestDto passwordRegisterRequest) {
+        passwordRegisterRequest.updatePasswordToEncrypt(encoder.encode(passwordRegisterRequest.getPassword()));
+        var userInfo = userRegisterService.registerUser(passwordRegisterRequest).convertToUserInfo();
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
         return ResponseEntity.ok().build();
     }

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
@@ -3,13 +3,19 @@ package site.archive.web.api.v2;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.archive.dto.v1.user.UserPasswordResetRequestDtoV1;
+import site.archive.dto.v2.PasswordRegisterRequestDto;
+import site.archive.infra.user.oauth.OAuthUserService;
 import site.archive.service.user.UserAuthService;
+import site.archive.service.user.UserRegisterServiceV2;
+import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
 
 @RestController
 @RequestMapping("/api/v2/auth")
@@ -17,11 +23,23 @@ import site.archive.service.user.UserAuthService;
 public class UserAuthControllerV2 {
 
     private final UserAuthService userAuthService;
+    private final UserRegisterServiceV2 userRegisterService;
+    private final OAuthUserService oAuthUserService;
+    private final PasswordEncoder encoder;
 
     @Operation(summary = "비밀번호 초기화 - 새로운 비밀번호 설정")
     @PostMapping("/password/reset")
     public ResponseEntity<Void> resetPassword(@Validated @RequestBody UserPasswordResetRequestDtoV1 userPasswordResetRequestDtoV1) {
         userAuthService.resetPassword(userPasswordResetRequestDtoV1);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "[NoAuth] 패스워드 유저 회원가입")
+    @PostMapping("/register")
+    public ResponseEntity<Void> registerPasswordUser(@Validated @RequestBody PasswordRegisterRequestDto registerRequest) {
+        registerRequest.updatePasswordToEncrypt(encoder.encode(registerRequest.getPassword()));
+        var userInfo = userRegisterService.registerUser(registerRequest).convertToUserInfo();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userInfo));
         return ResponseEntity.ok().build();
     }
 

--- a/archive-web/src/main/java/site/archive/web/config/WebConfigurer.java
+++ b/archive-web/src/main/java/site/archive/web/config/WebConfigurer.java
@@ -38,7 +38,7 @@ public class WebConfigurer implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new InjectTokenInterceptor(tokenProvider, tokenSupport))
-                .addPathPatterns("/api/v1/auth/**");
+                .addPathPatterns("/api/v1/auth/**", "/api/v2/auth/register/**");
     }
 
 }

--- a/archive-web/src/main/java/site/archive/web/config/WebConfigurer.java
+++ b/archive-web/src/main/java/site/archive/web/config/WebConfigurer.java
@@ -38,7 +38,9 @@ public class WebConfigurer implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new InjectTokenInterceptor(tokenProvider, tokenSupport))
-                .addPathPatterns("/api/v1/auth/**", "/api/v2/auth/register/**");
+                .addPathPatterns("/api/v1/auth/**",
+                                 "/api/v2/auth/register/**",
+                                 "/api/v2/auth/login/social");
     }
 
 }

--- a/archive-web/src/main/java/site/archive/web/config/security/SecurityConfig.java
+++ b/archive-web/src/main/java/site/archive/web/config/security/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                    .authorizeRequests()
                        .antMatchers("/api/v1/**").permitAll()
                        .antMatchers("/api/v2/user/duplicate/**").permitAll()
+                       .antMatchers("/api/v2/auth/register/**").permitAll()
                        .antMatchers("/login/**").permitAll()
                        .antMatchers(HttpMethod.GET, "/exception/**").permitAll()
                        .anyRequest().authenticated().and()

--- a/archive-web/src/main/java/site/archive/web/config/security/SecurityConfig.java
+++ b/archive-web/src/main/java/site/archive/web/config/security/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                        .antMatchers("/api/v1/**").permitAll()
                        .antMatchers("/api/v2/user/duplicate/**").permitAll()
                        .antMatchers("/api/v2/auth/register/**").permitAll()
+                       .antMatchers("/api/v2/auth/login/social").permitAll()
                        .antMatchers("/login/**").permitAll()
                        .antMatchers(HttpMethod.GET, "/exception/**").permitAll()
                        .anyRequest().authenticated().and()


### PR DESCRIPTION
- Nickname 필드가 추가됨에 따라 Register, Login v2 endpoint 생성
  - 기존 로직과 대부분 동일하나 Register 시에 `nickname` 필드 추가

- OAuth 로그인의 경우, Register/Login이 같은 endpoint로 묶여있었어서 기존 그대로 하게되면 `nickname`을 로그인 시에도 받게 되는 문제가 생김. 이에 Register/Login endpoint를 분리함.

- 기능을 추가하며 v1 Oauth Client 로직 쪽 코드 리팩터링 수행