### PR TITLE
feat: archive 상세 조회 api 수정 (v2) - nickname, profileImage 추가

### DIFF
--- a/archive-application/src/main/java/site/archive/dto/v2/ArchiveDtoV2.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/ArchiveDtoV2.java
@@ -1,0 +1,86 @@
+package site.archive.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.archive.domain.archive.Archive;
+import site.archive.domain.archive.Emotion;
+import site.archive.domain.user.BaseUser;
+import site.archive.dto.v1.archive.ArchiveImageDtoV1;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static site.archive.common.DateTimeUtil.YY_MM_DD_FORMATTER;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchiveDtoV2 {
+
+    private Long archiveId;
+    private String name;
+    private String watchedOn;
+    private Emotion emotion;
+    private String mainImage;
+    private Boolean isPublic;       // Default value is false
+
+    private long authorId;
+    private String nickname;
+    private String profileImage;
+
+    private List<String> companions;
+    private List<ArchiveImageDtoV1> images;
+
+    public static ArchiveDtoV2 specificFrom(Archive archive) {
+        var archiveImages = archive.getArchiveImages().stream()
+                                   .map(ArchiveImageDtoV1::from)
+                                   .toList();
+        return ArchiveDtoV2.builder()
+                           .archiveId(archive.getId())
+                           .name(archive.getName())
+                           .watchedOn(archive.getWatchedOn().format(YY_MM_DD_FORMATTER))
+                           .emotion(archive.getEmotion())
+                           .mainImage(archive.getMainImage())
+                           .companions(archive.getCompanions())
+                           .images(archiveImages)
+                           .authorId(archive.getAuthor().getId())
+                           .nickname(archive.getAuthor().getNickname())
+                           .profileImage(archive.getAuthor().getProfileImage())
+                           .isPublic(archive.getIsPublic())
+                           .build();
+    }
+
+    public static ArchiveDtoV2 simpleFrom(Archive archive) {
+        return ArchiveDtoV2.builder()
+                           .archiveId(archive.getId())
+                           .name(archive.getName())
+                           .watchedOn(archive.getWatchedOn().format(YY_MM_DD_FORMATTER))
+                           .emotion(archive.getEmotion())
+                           .companions(archive.getCompanions())
+                           .mainImage(archive.getMainImage())
+                           .authorId(archive.getAuthor().getId())
+                           .nickname(archive.getAuthor().getNickname())
+                           .profileImage(archive.getAuthor().getProfileImage())
+                           .isPublic(archive.getIsPublic())
+                           .build();
+    }
+
+    public Archive toEntity(BaseUser user) {
+        var defaultIsPublic = this.isPublic != null && this.isPublic;
+        return Archive.builder()
+                      .name(name)
+                      .watchedOn(LocalDate.parse(watchedOn, YY_MM_DD_FORMATTER))
+                      .emotion(emotion)
+                      .mainImage(mainImage)
+                      .companions(companions)
+                      .author(user)
+                      .isPublic(defaultIsPublic)
+                      .build();
+    }
+
+}

--- a/archive-application/src/main/java/site/archive/dto/v2/ArchiveDtoV2.java
+++ b/archive-application/src/main/java/site/archive/dto/v2/ArchiveDtoV2.java
@@ -40,6 +40,7 @@ public class ArchiveDtoV2 {
         var archiveImages = archive.getArchiveImages().stream()
                                    .map(ArchiveImageDtoV1::from)
                                    .toList();
+        var author = archive.getAuthor();
         return ArchiveDtoV2.builder()
                            .archiveId(archive.getId())
                            .name(archive.getName())
@@ -48,39 +49,10 @@ public class ArchiveDtoV2 {
                            .mainImage(archive.getMainImage())
                            .companions(archive.getCompanions())
                            .images(archiveImages)
-                           .authorId(archive.getAuthor().getId())
-                           .nickname(archive.getAuthor().getNickname())
-                           .profileImage(archive.getAuthor().getProfileImage())
+                           .authorId(author.getId())
+                           .nickname(author.getNickname())
+                           .profileImage(author.getProfileImage())
                            .isPublic(archive.getIsPublic())
                            .build();
     }
-
-    public static ArchiveDtoV2 simpleFrom(Archive archive) {
-        return ArchiveDtoV2.builder()
-                           .archiveId(archive.getId())
-                           .name(archive.getName())
-                           .watchedOn(archive.getWatchedOn().format(YY_MM_DD_FORMATTER))
-                           .emotion(archive.getEmotion())
-                           .companions(archive.getCompanions())
-                           .mainImage(archive.getMainImage())
-                           .authorId(archive.getAuthor().getId())
-                           .nickname(archive.getAuthor().getNickname())
-                           .profileImage(archive.getAuthor().getProfileImage())
-                           .isPublic(archive.getIsPublic())
-                           .build();
-    }
-
-    public Archive toEntity(BaseUser user) {
-        var defaultIsPublic = this.isPublic != null && this.isPublic;
-        return Archive.builder()
-                      .name(name)
-                      .watchedOn(LocalDate.parse(watchedOn, YY_MM_DD_FORMATTER))
-                      .emotion(emotion)
-                      .mainImage(mainImage)
-                      .companions(companions)
-                      .author(user)
-                      .isPublic(defaultIsPublic)
-                      .build();
-    }
-
 }

--- a/archive-application/src/main/java/site/archive/service/archive/ArchiveService.java
+++ b/archive-application/src/main/java/site/archive/service/archive/ArchiveService.java
@@ -141,16 +141,6 @@ public class ArchiveService {
                     .forEach(archive::addImage);
     }
 
-    @Transactional
-    public void save(ArchiveDtoV2 archiveDtoV2, Long authorId) {
-        var user = userRepository.findById(authorId)
-                                 .orElseThrow(() -> new ResourceNotFoundException("아이디에 해당하는 유저가 존재하지 않습니다."));
-        var archive = archiveRepository.save(archiveDtoV2.toEntity(user));
-        archiveDtoV2.getImages().stream()
-                    .map(archiveImageDto -> archiveImageDto.toEntity(archive))
-                    .forEach(archive::addImage);
-    }
-
     public long countArchive(UserInfo userInfo) {
         var authorId = userInfo.getUserId();
         return archiveRepository.countArchiveByAuthorId(authorId);

--- a/archive-application/src/main/java/site/archive/service/archive/ArchiveService.java
+++ b/archive-application/src/main/java/site/archive/service/archive/ArchiveService.java
@@ -13,6 +13,7 @@ import site.archive.domain.user.UserInfo;
 import site.archive.domain.user.UserRepository;
 import site.archive.dto.v1.archive.ArchiveDtoV1;
 import site.archive.dto.v1.archive.ArchiveListResponseDtoV1;
+import site.archive.dto.v2.ArchiveDtoV2;
 import site.archive.dto.v2.ArchiveLikeResponseDto;
 import site.archive.dto.v2.MyArchiveResponseDto;
 
@@ -118,9 +119,9 @@ public class ArchiveService {
      * @param archiveId 상세 조회하려는 Archive id
      * @return Archive
      */
-    public ArchiveDtoV1 getOneArchiveById(UserInfo userInfo, Long archiveId) {
+    public ArchiveDtoV2 getOneArchiveById(UserInfo userInfo, Long archiveId) {
         var archive = getOneArchiveOnlyHasAuthority(userInfo, archiveId);
-        return ArchiveDtoV1.specificFrom(archive);
+        return ArchiveDtoV2.specificFrom(archive);
     }
 
     @Transactional
@@ -136,6 +137,16 @@ public class ArchiveService {
                                  .orElseThrow(() -> new ResourceNotFoundException("아이디에 해당하는 유저가 존재하지 않습니다."));
         var archive = archiveRepository.save(archiveDtoV1.toEntity(user));
         archiveDtoV1.getImages().stream()
+                    .map(archiveImageDto -> archiveImageDto.toEntity(archive))
+                    .forEach(archive::addImage);
+    }
+
+    @Transactional
+    public void save(ArchiveDtoV2 archiveDtoV2, Long authorId) {
+        var user = userRepository.findById(authorId)
+                                 .orElseThrow(() -> new ResourceNotFoundException("아이디에 해당하는 유저가 존재하지 않습니다."));
+        var archive = archiveRepository.save(archiveDtoV2.toEntity(user));
+        archiveDtoV2.getImages().stream()
                     .map(archiveImageDto -> archiveImageDto.toEntity(archive))
                     .forEach(archive::addImage);
     }

--- a/archive-web/src/main/java/site/archive/web/api/v2/ArchiveControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/ArchiveControllerV2.java
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.archive.domain.archive.custom.ArchivePageable;
 import site.archive.domain.user.UserInfo;
-import site.archive.dto.v1.archive.ArchiveDtoV1;
 import site.archive.dto.v1.archive.ArchiveListResponseDtoV1;
 import site.archive.dto.v2.ArchiveCountResponseDto;
+import site.archive.dto.v2.ArchiveDtoV2;
 import site.archive.dto.v2.MyArchiveListResponseDto;
 import site.archive.service.archive.ArchiveService;
 import site.archive.web.api.resolver.annotation.RequestUser;
@@ -45,7 +45,7 @@ public class ArchiveControllerV2 {
 
     @Operation(summary = "아카이브 상세 조회")
     @GetMapping("/{archiveId}")
-    public ResponseEntity<ArchiveDtoV1> archiveSpecificView(@RequestUser UserInfo userInfo,
+    public ResponseEntity<ArchiveDtoV2> archiveSpecificView(@RequestUser UserInfo userInfo,
                                                             @PathVariable Long archiveId) {
         return ResponseEntity.ok(archiveService.getOneArchiveById(userInfo, archiveId));
     }


### PR DESCRIPTION
- `ArchiveDtoV1`에 `nickname`, `profileImage` 필드를 추가한 `ArchiveDtoV2`를 생성하였습니다.
- `ArchiveService`에서 `getOneArchiveById`의 리턴값을 `ArchiveDtoV2`로 변경하였습니다.
- `ArchiveControllerV2`에서 `archiveSpecificView`의 리턴값을 `ResponseEntity<ArchiveDtoV1>`를 `ResponseEntity<ArchiveDtoV2>`로 변경하였습니다.