### PR TITLE
feat: extract docs responsibility to Docs interfaces using springdoc-openapi

### DIFF
--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveCommunityControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveCommunityControllerV2Docs.java
@@ -1,0 +1,20 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import site.archive.domain.archive.custom.ArchivePageable;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v2.ArchiveCommunityResponseDto;
+
+import java.util.List;
+
+public interface ArchiveCommunityControllerV2Docs {
+
+    @Operation(summary = "아카이브 전시소통 리스트 조회")
+    @GetMapping
+    ResponseEntity<List<ArchiveCommunityResponseDto>> archiveCommunityView(UserInfo user,
+                                                                           @ParameterObject ArchivePageable pageable);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveControllerV1Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveControllerV1Docs.java
@@ -1,0 +1,34 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v1.archive.ArchiveCountResponseDtoV1;
+import site.archive.dto.v1.archive.ArchiveDtoV1;
+import site.archive.dto.v1.archive.ArchiveImageUrlResponseDtoV1;
+import site.archive.dto.v1.archive.ArchiveListResponseDtoV1;
+
+public interface ArchiveControllerV1Docs {
+
+    @Operation(summary = "아카이브 리스트 조회", description = "홈 뷰 - 아카이브 리스트 조회")
+    ResponseEntity<ArchiveListResponseDtoV1> archiveListView(UserInfo user);
+
+    @Operation(summary = "아카이브 상세 조회", description = "상세 뷰 - 아카이브 상세 조회")
+    ResponseEntity<ArchiveDtoV1> archiveSpecificView(@Parameter(name = "id", description = "상세 조회할 archive index (id)") Long id);
+
+    @Operation(summary = "아카이브 삭제", description = "아카이브 제거 - 실제 제거 X")
+    void delete(@Parameter(name = "id", description = "제거할 archive index (id)") Long id);
+
+    @Operation(summary = "[Deprecated -> /api/v2/user/profile/image/upload] 이미지 업로드")
+    ResponseEntity<ArchiveImageUrlResponseDtoV1> uploadImage(
+        @Parameter(name = "image", description = "업로드할 이미지 파일") MultipartFile imageFile);
+
+    @Operation(summary = "아키이브 추가")
+    ResponseEntity<Object> addArchive(UserInfo user, ArchiveDtoV1 archiveDtoV1);
+
+    @Operation(summary = "아카이브 개수 조회")
+    ResponseEntity<ArchiveCountResponseDtoV1> countArchive(UserInfo user);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveControllerV2Docs.java
@@ -1,0 +1,36 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import site.archive.domain.archive.custom.ArchivePageable;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v1.archive.ArchiveListResponseDtoV1;
+import site.archive.dto.v2.ArchiveCountResponseDto;
+import site.archive.dto.v2.ArchiveDtoV2;
+import site.archive.dto.v2.MyArchiveListResponseDto;
+
+public interface ArchiveControllerV2Docs {
+
+    @Operation(summary = "나의 관람 뷰 (아카이브 리스트)", description = "홈 뷰 - 아카이브 리스트 조회")
+    ResponseEntity<MyArchiveListResponseDto> archiveListView(UserInfo userInfo,
+                                                             @ParameterObject ArchivePageable pageable);
+
+    @Operation(summary = "특정 유저 아카이브 리스트 조회")
+    ResponseEntity<ArchiveListResponseDtoV1> archiveListView(UserInfo userInfo,
+                                                             @Parameter(name = "userId", description = "조회하고자 하는 유저 Index") Long userId);
+
+    @Operation(summary = "아카이브 상세 조회")
+    ResponseEntity<ArchiveDtoV2> archiveSpecificView(UserInfo userInfo,
+                                                     @Parameter(name = "archiveId", description = "archive Index (Id)") Long archiveId);
+
+    @Operation(summary = "이번 달 아카이브 개수 조회")
+    ResponseEntity<ArchiveCountResponseDto> countArchiveOfCurrentMonth(UserInfo userInfo);
+
+    @Operation(summary = "아카이브 공개여부 설정/수정")
+    ResponseEntity<Void> archivePublicPrivate(UserInfo userInfo,
+                                              @Parameter(name = "archiveId", description = "archive Index (Id)") Long archiveId,
+                                              Boolean isPublic);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveImageControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveImageControllerV2Docs.java
@@ -1,0 +1,18 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+import site.archive.dto.v1.archive.ArchiveImageUrlResponseDtoV1;
+
+public interface ArchiveImageControllerV2Docs {
+
+    @Operation(summary = "이미지 업로드")
+    ResponseEntity<ArchiveImageUrlResponseDtoV1> uploadImage(
+        @Parameter(name = "imageFile", description = "업로드 할 이미지 파일") MultipartFile imageFile);
+
+    @Operation(summary = "이미지 제거")
+    ResponseEntity<Void> removeImage(@Parameter(name = "fileUri", description = "제거할 이미지 파일 주소") String fileUri);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveLikeControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/ArchiveLikeControllerV2Docs.java
@@ -1,0 +1,13 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v2.ArchiveLikeListResponseDto;
+
+public interface ArchiveLikeControllerV2Docs {
+
+    @Operation(summary = "좋아요 한 Archive 조회")
+    ResponseEntity<ArchiveLikeListResponseDto> archiveLikeListView(UserInfo userInfo);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/BannerControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/BannerControllerV2Docs.java
@@ -1,0 +1,29 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+import site.archive.dto.v2.BannerListResponseDto;
+
+public interface BannerControllerV2Docs {
+
+    @Operation(summary = "배너 조회 [캐싱 - 1시간]")
+    ResponseEntity<BannerListResponseDto> archiveCommunityBannerView();
+
+    @Operation(summary = "배너 생성 (업로드) - 이미지 타입")
+    ResponseEntity<Void> createArchiveCommunityBanner(
+        @Parameter(name = "summaryImage", description = "전시소통 배너칸 노출 이미지") MultipartFile summaryImage,
+        @Parameter(name = "mainImage", description = "배너 메인 이미지") MultipartFile mainImage);
+
+    @Operation(summary = "배너 생성 (업로드) - URL 타입")
+    ResponseEntity<Void> createArchiveCommunityBanner(
+        @Parameter(name = "summaryImage", description = "전시소통 배너칸 노출 이미지") MultipartFile summaryImage,
+        @Parameter(name = "mainContentUrl", description = "배너 연결 URL") String mainContentUrl);
+
+    @Operation(summary = "배너 제거")
+    ResponseEntity<Void> deleteArchiveCommunityBanner(@Parameter(name = "bannerId", description = "제거할 배너 Index") Long bannerId);
+
+}
+
+

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/LikeControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/LikeControllerV2Docs.java
@@ -1,0 +1,30 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v2.LikesRequestDto;
+import site.archive.dto.v2.UnlikesRequestDto;
+
+public interface LikeControllerV2Docs {
+
+    @Operation(summary = "좋아요 추가")
+    ResponseEntity<Void> like(UserInfo user,
+                              @Parameter(name = "archiveId", description = "좋아요 할 아카이브 Index (Id)") Long archiveId);
+
+    @Operation(summary = "좋아요 추가 (Bulk)")
+    ResponseEntity<Void> likeBulk(UserInfo user,
+                                  @Parameter(name = "likesRequest", description = "좋아요 할 아카이브 Index list") LikesRequestDto likesRequest);
+
+    @Operation(summary = "좋아요 삭제")
+    ResponseEntity<Void> unlike(UserInfo user,
+                                @Parameter(name = "archiveId", description = "좋아요 취소할 아카이브 Index (Id)") Long archiveId);
+
+
+    @Operation(summary = "좋아요 삭제 (Bulk)")
+    ResponseEntity<Void> unlikeBulk(UserInfo user,
+                                    @Parameter(name = "unlikesRequest", description = "좋아요 취소할 아카이브 Index list")
+                                    UnlikesRequestDto unlikesRequest);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/RegisterControllerV1Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/RegisterControllerV1Docs.java
@@ -1,0 +1,16 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import site.archive.dto.v1.auth.PasswordRegisterCommandV1;
+import site.archive.dto.v1.user.OAuthRegisterRequestDtoV1;
+
+public interface RegisterControllerV1Docs {
+
+    @Operation(summary = "[Deprecated -> /api/v2/auth/register] 패스워드 유저 회원가입")
+    ResponseEntity<Void> registerUser(PasswordRegisterCommandV1 command);
+
+    @Operation(summary = "[Deprecated -> /api/v2/auth/register/social, login/social] 소셜 로그인 유저 회원가입 및 로그인")
+    ResponseEntity<Void> registerOrLoginSocialUser(OAuthRegisterRequestDtoV1 oAuthRegisterRequestDtoV1);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/ReportControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/ReportControllerV2Docs.java
@@ -1,0 +1,25 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v2.ReportCheckResponse;
+import site.archive.dto.v2.ReportRequestDto;
+
+public interface ReportControllerV2Docs {
+
+    @Operation(summary = "신고 여부 확인")
+    ResponseEntity<ReportCheckResponse> isReport(UserInfo userInfo,
+                                                 @Parameter(name = "archiveId", description = "신고여부 확인할 archive Index") Long archiveId);
+
+    @Operation(summary = "신고하기")
+    ResponseEntity<Void> report(UserInfo userInfo,
+                                @Parameter(name = "archiveId", description = "신고할 archive Index") Long archiveId,
+                                ReportRequestDto reportRequestDto);
+
+    @Operation(summary = "신고 취소하기")
+    ResponseEntity<Void> reportCancel(UserInfo userInfo,
+                                      @Parameter(name = "archiveId", description = "신고 취소할 archive Index") Long archiveId);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/UserAuthControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/UserAuthControllerV2Docs.java
@@ -1,0 +1,26 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v1.user.UserPasswordResetRequestDtoV1;
+import site.archive.dto.v2.OAuthLoginRequestDto;
+import site.archive.dto.v2.OAuthUserInfoRequestDto;
+import site.archive.dto.v2.PasswordRegisterRequestDto;
+
+public interface UserAuthControllerV2Docs {
+
+    @Operation(summary = "비밀번호 초기화 - 새로운 비밀번호 설정")
+    ResponseEntity<Void> resetPassword(UserInfo userInfo,
+                                       UserPasswordResetRequestDtoV1 userPasswordResetRequestDtoV1);
+
+    @Operation(summary = "[NoAuth] 패스워드 유저 회원가입")
+    ResponseEntity<Void> registerPasswordUser(PasswordRegisterRequestDto passwordRegisterRequest);
+
+    @Operation(summary = "[NoAuth] 소셜 유저 회원가입")
+    ResponseEntity<Void> registerSocialUser(OAuthUserInfoRequestDto oAuthUserInfoRequest);
+
+    @Operation(summary = "[NoAuth] 소셜 유저 로그인")
+    ResponseEntity<Void> loginSocialUser(OAuthLoginRequestDto oAuthLoginRequestDto);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/UserControllerV1Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/UserControllerV1Docs.java
@@ -1,0 +1,33 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v1.archive.EmailDuplicateResponseDtoV1;
+import site.archive.dto.v1.auth.LoginCommandV1;
+import site.archive.dto.v1.user.UserEmailRequestDtoV1;
+import site.archive.dto.v1.user.UserPasswordResetRequestDtoV1;
+
+public interface UserControllerV1Docs {
+
+    @Operation(summary = "패스워드 유저 로그인")
+    void loginUser(LoginCommandV1 loginCommandV1);
+
+    @Operation(summary = "회원 탈퇴")
+    ResponseEntity<Void> unregisterUser(UserInfo user);
+
+    @Operation(summary = "[Deprecated -> /api/v2/user/profile] 자기 정보 조회")
+    ResponseEntity<UserInfo> getUserInfo(UserInfo user);
+
+    @Operation(summary = "[Deprecated -> /api/v2/user/duplicate/email] 이메일 중복 검사")
+    ResponseEntity<EmailDuplicateResponseDtoV1> checkDuplicatedEmail(
+        @Parameter(name = "email", description = "중복검사 하려는 이메일 주소") String email);
+
+    @Operation(summary = "비밀번호 초기화 - 임시 비밀번호 발급")
+    ResponseEntity<Void> issueTemporaryPassword(UserEmailRequestDtoV1 userEmailRequestDtoV1);
+
+    @Operation(summary = "[Deprecated -> /api/v2/auth/password/reset] 비밀번호 초기화 - 새로운 비밀번호 설정")
+    ResponseEntity<Void> resetPassword(UserPasswordResetRequestDtoV1 userPasswordResetRequestDtoV1);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/UserControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/UserControllerV2Docs.java
@@ -1,0 +1,24 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v1.archive.EmailDuplicateResponseDtoV1;
+import site.archive.dto.v2.NicknameDuplicateResponseDto;
+import site.archive.dto.v2.UserNicknameUpdateRequest;
+
+public interface UserControllerV2Docs {
+
+    @Operation(summary = "[NoAuth] 이메일 중복 검사")
+    ResponseEntity<EmailDuplicateResponseDtoV1> checkDuplicatedEmail(
+        @Parameter(name = "value", description = "중복검사 할 이메일 주소") String email);
+
+    @Operation(summary = "[NoAuth] 닉네임 중복 검사")
+    ResponseEntity<NicknameDuplicateResponseDto> checkDuplicatedNickname(
+        @Parameter(name = "value", description = "중복검사 할 닉네임") String nickname);
+
+    @Operation(summary = "프로필 닉네임 수정 (업데이트)")
+    ResponseEntity<Void> updateProfileNickname(UserInfo user, UserNicknameUpdateRequest request);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/docs/swagger/UserProfileControllerV2Docs.java
+++ b/archive-web/src/main/java/site/archive/web/api/docs/swagger/UserProfileControllerV2Docs.java
@@ -1,0 +1,22 @@
+package site.archive.web.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+import site.archive.domain.user.UserInfo;
+import site.archive.dto.v1.user.SpecificUserDtoV1;
+
+public interface UserProfileControllerV2Docs {
+
+    @Operation(summary = "프로필 정보 조회")
+    ResponseEntity<SpecificUserDtoV1> getUserProfileInfo(UserInfo user);
+
+    @Operation(summary = "프로필 이미지 업로드 및 업데이트")
+    ResponseEntity<Void> uploadProfileImage(UserInfo user,
+                                            @Parameter(name = "image", description = "프로필 이미지 파일") MultipartFile imageFile);
+
+    @Operation(summary = "프로필 이미지 제거")
+    ResponseEntity<Void> removeProfileImage(UserInfo user);
+
+}

--- a/archive-web/src/main/java/site/archive/web/api/v1/ArchiveControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/ArchiveControllerV1.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v1;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -14,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import site.archive.common.FileUtils;
 import site.archive.domain.user.UserInfo;
 import site.archive.dto.v1.archive.ArchiveCountResponseDtoV1;
 import site.archive.dto.v1.archive.ArchiveDtoV1;
@@ -21,43 +21,39 @@ import site.archive.dto.v1.archive.ArchiveImageUrlResponseDtoV1;
 import site.archive.dto.v1.archive.ArchiveListResponseDtoV1;
 import site.archive.service.archive.ArchiveImageService;
 import site.archive.service.archive.ArchiveService;
+import site.archive.web.api.docs.swagger.ArchiveControllerV1Docs;
 import site.archive.web.api.resolver.annotation.RequestUser;
 import site.archive.web.config.security.authz.AdminOrAuthorChecker;
 import site.archive.web.config.security.authz.annotation.RequirePermission;
-import site.archive.common.FileUtils;
 
 import static site.archive.service.archive.ArchiveImageService.ARCHIVE_IMAGE_DIRECTORY;
 
 @RestController
 @RequestMapping("/api/v1/archive")
 @RequiredArgsConstructor
-public class ArchiveControllerV1 {
+public class ArchiveControllerV1 implements ArchiveControllerV1Docs {
 
     private final ArchiveService archiveService;
     private final ArchiveImageService imageService;
 
-    @Operation(summary = "아카이브 리스트 조회", description = "홈 뷰 - 아카이브 리스트 조회")
     @GetMapping
     public ResponseEntity<ArchiveListResponseDtoV1> archiveListView(@RequestUser UserInfo user) {
         return ResponseEntity.ok(archiveService.getAllArchive(user));
     }
 
     @RequirePermission(handler = AdminOrAuthorChecker.class, id = "id")
-    @Operation(summary = "아카이브 상세 조회", description = "상세 뷰 - 아카이브 상세 조회")
     @GetMapping("/{id}")
     public ResponseEntity<ArchiveDtoV1> archiveSpecificView(@PathVariable Long id) {
         return ResponseEntity.ok(archiveService.getOneArchiveById(id));
     }
 
     @RequirePermission(handler = AdminOrAuthorChecker.class, id = "id")
-    @Operation(summary = "아카이브 삭제", description = "아카이브 제거 - 실제 제거 X")
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         archiveService.delete(id);
     }
 
     @Deprecated
-    @Operation(summary = "[Deprecated -> /api/v2/user/profile/image/upload] 이미지 업로드")
     @PostMapping(path = "/image/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ArchiveImageUrlResponseDtoV1> uploadImage(@RequestParam("image") MultipartFile imageFile) {
         FileUtils.verifyImageFile(imageFile);
@@ -65,14 +61,12 @@ public class ArchiveControllerV1 {
         return ResponseEntity.ok(new ArchiveImageUrlResponseDtoV1(imageUri));
     }
 
-    @Operation(summary = "아키이브 추가")
     @PostMapping
     public ResponseEntity<Object> addArchive(@RequestUser UserInfo user, @RequestBody ArchiveDtoV1 archiveDtoV1) {
         archiveService.save(archiveDtoV1, user.getUserId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "아카이브 개수 조회")
     @GetMapping("/count")
     public ResponseEntity<ArchiveCountResponseDtoV1> countArchive(@RequestUser UserInfo user) {
         var archiveCountDto = new ArchiveCountResponseDtoV1(archiveService.countArchive(user));

--- a/archive-web/src/main/java/site/archive/web/api/v1/RegisterControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/RegisterControllerV1.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v1;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,19 +13,19 @@ import site.archive.dto.v1.auth.PasswordRegisterCommandV1;
 import site.archive.dto.v1.user.OAuthRegisterRequestDtoV1;
 import site.archive.infra.user.oauth.OAuthUserService;
 import site.archive.service.user.UserRegisterServiceV1;
+import site.archive.web.api.docs.swagger.RegisterControllerV1Docs;
 import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class RegisterControllerV1 {
+public class RegisterControllerV1 implements RegisterControllerV1Docs {
 
     private final UserRegisterServiceV1 userRegisterServiceV1;
     private final OAuthUserService oAuthUserService;
     private final PasswordEncoder encoder;
 
     @Deprecated
-    @Operation(summary = "[Deprecated -> /api/v2/auth/register] 패스워드 유저 회원가입")
     @PostMapping("/register")
     public ResponseEntity<Void> registerUser(@Validated @RequestBody PasswordRegisterCommandV1 command) {
         command.setPassword(encoder.encode(command.getPassword()));
@@ -36,7 +35,6 @@ public class RegisterControllerV1 {
     }
 
     @Deprecated
-    @Operation(summary = "[Deprecated -> /api/v2/auth/register/social, login/social] 소셜 로그인 유저 회원가입 및 로그인")
     @PostMapping("/social")
     public ResponseEntity<Void> registerOrLoginSocialUser(@Validated @RequestBody OAuthRegisterRequestDtoV1 oAuthRegisterRequestDtoV1) {
         var oAuthRegisterInfo = oAuthUserService.getOAuthRegisterInfo(oAuthRegisterRequestDtoV1);

--- a/archive-web/src/main/java/site/archive/web/api/v1/UserControllerV1.java
+++ b/archive-web/src/main/java/site/archive/web/api/v1/UserControllerV1.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v1;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -18,20 +17,20 @@ import site.archive.dto.v1.user.UserEmailRequestDtoV1;
 import site.archive.dto.v1.user.UserPasswordResetRequestDtoV1;
 import site.archive.service.user.UserAuthService;
 import site.archive.service.user.UserService;
+import site.archive.web.api.docs.swagger.UserControllerV1Docs;
 import site.archive.web.api.resolver.annotation.RequestUser;
 import site.archive.web.config.security.util.SecurityUtils;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class UserControllerV1 {
+public class UserControllerV1 implements UserControllerV1Docs {
 
     private static final int TEMP_PASSWORD_LENGTH = 10;
     private final UserService userService;
     private final UserAuthService userAuthService;
 
     @SuppressWarnings(value = "all")
-    @Operation(summary = "패스워드 유저 로그인")
     @PostMapping("/login")
     public void loginUser(@RequestBody LoginCommandV1 loginCommandV1) {
         /*
@@ -40,7 +39,6 @@ public class UserControllerV1 {
          */
     }
 
-    @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/unregister")
     public ResponseEntity<Void> unregisterUser(@RequestUser UserInfo user) {
         userService.deleteUser(user.getUserId());
@@ -48,21 +46,18 @@ public class UserControllerV1 {
     }
 
     @Deprecated
-    @Operation(summary = "[Deprecated -> /api/v2/user/profile] 자기 정보 조회")
     @GetMapping("/info")
     public ResponseEntity<UserInfo> getUserInfo(@RequestUser UserInfo user) {
         return ResponseEntity.ok(user);
     }
 
     @Deprecated
-    @Operation(summary = "[Deprecated -> /api/v2/user/duplicate/email] 이메일 중복 검사")
     @GetMapping("/email/{email}")
     public ResponseEntity<EmailDuplicateResponseDtoV1> checkDuplicatedEmail(@PathVariable String email) {
         var emailDuplicateResponseDto = new EmailDuplicateResponseDtoV1(userService.existsEmail(email));
         return ResponseEntity.ok(emailDuplicateResponseDto);
     }
 
-    @Operation(summary = "비밀번호 초기화 - 임시 비밀번호 발급")
     @PostMapping("/password/temporary")
     public ResponseEntity<Void> issueTemporaryPassword(@Validated @RequestBody UserEmailRequestDtoV1 userEmailRequestDtoV1) {
         var temporaryPassword = SecurityUtils.generateRandomString(TEMP_PASSWORD_LENGTH);
@@ -71,7 +66,6 @@ public class UserControllerV1 {
     }
 
     @Deprecated
-    @Operation(summary = "[Deprecated -> /api/v2/auth/password/reset] 비밀번호 초기화 - 새로운 비밀번호 설정")
     @PostMapping("/password/reset")
     public ResponseEntity<Void> resetPassword(@Validated @RequestBody UserPasswordResetRequestDtoV1 userPasswordResetRequestDtoV1) {
         userAuthService.resetPassword(userPasswordResetRequestDtoV1);

--- a/archive-web/src/main/java/site/archive/web/api/v2/ArchiveCommunityControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/ArchiveCommunityControllerV2.java
@@ -1,8 +1,6 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,20 +10,20 @@ import site.archive.domain.user.UserInfo;
 import site.archive.dto.v2.ArchiveCommunityResponseDto;
 import site.archive.service.archive.ArchiveCommunityService;
 import site.archive.web.api.resolver.annotation.RequestUser;
+import site.archive.web.api.docs.swagger.ArchiveCommunityControllerV2Docs;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/v2/archive/community")
 @RequiredArgsConstructor
-public class ArchiveCommunityControllerV2 {
+public class ArchiveCommunityControllerV2 implements ArchiveCommunityControllerV2Docs {
 
     private final ArchiveCommunityService archiveCommunityService;
 
-    @Operation(summary = "아카이브 전시소통 리스트 조회")
     @GetMapping
     public ResponseEntity<List<ArchiveCommunityResponseDto>> archiveCommunityView(@RequestUser UserInfo user,
-                                                                                  @ParameterObject ArchivePageable pageable) {
+                                                                                  ArchivePageable pageable) {
         if (pageable.isRequestFirstPage()) {
             return ResponseEntity.ok(archiveCommunityService.getCommunityFirstPage(user.getUserId(), pageable));
         }

--- a/archive-web/src/main/java/site/archive/web/api/v2/ArchiveControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/ArchiveControllerV2.java
@@ -1,8 +1,6 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,18 +16,18 @@ import site.archive.dto.v2.ArchiveDtoV2;
 import site.archive.dto.v2.MyArchiveListResponseDto;
 import site.archive.service.archive.ArchiveService;
 import site.archive.web.api.resolver.annotation.RequestUser;
+import site.archive.web.api.docs.swagger.ArchiveControllerV2Docs;
 
 @RestController
 @RequestMapping("/api/v2/archive")
 @RequiredArgsConstructor
-public class ArchiveControllerV2 {
+public class ArchiveControllerV2 implements ArchiveControllerV2Docs {
 
     private final ArchiveService archiveService;
 
-    @Operation(summary = "나의 관람 뷰 (아카이브 리스트)", description = "홈 뷰 - 아카이브 리스트 조회")
     @GetMapping
     public ResponseEntity<MyArchiveListResponseDto> archiveListView(@RequestUser UserInfo userInfo,
-                                                                    @ParameterObject ArchivePageable pageable) {
+                                                                    ArchivePageable pageable) {
         var archiveCount = archiveService.countArchive(userInfo);
         var myArchives = pageable.isRequestFirstPage()
                          ? archiveService.getAllArchiveFirstPage(userInfo, pageable)
@@ -37,28 +35,24 @@ public class ArchiveControllerV2 {
         return ResponseEntity.ok(MyArchiveListResponseDto.from(archiveCount, myArchives));
     }
 
-    @Operation(summary = "특정 유저 아카이브 리스트 조회")
     @GetMapping("/other")
     public ResponseEntity<ArchiveListResponseDtoV1> archiveListView(@RequestUser UserInfo userInfo,
                                                                     @RequestParam Long userId) {
         return ResponseEntity.ok(archiveService.getAllArchive(userInfo, userId));
     }
 
-    @Operation(summary = "아카이브 상세 조회")
     @GetMapping("/{archiveId}")
     public ResponseEntity<ArchiveDtoV2> archiveSpecificView(@RequestUser UserInfo userInfo,
                                                             @PathVariable Long archiveId) {
         return ResponseEntity.ok(archiveService.getOneArchiveById(userInfo, archiveId));
     }
 
-    @Operation(summary = "이번 달 아카이브 개수 조회")
     @GetMapping("/count/month")
     public ResponseEntity<ArchiveCountResponseDto> countArchiveOfCurrentMonth(@RequestUser UserInfo userInfo) {
         var count = archiveService.countArchiveOfCurrentMonth(userInfo);
         return ResponseEntity.ok(new ArchiveCountResponseDto(count));
     }
 
-    @Operation(summary = "아카이브 공개여부 설정/수정")
     @PutMapping("/{archiveId}")
     public ResponseEntity<Void> archivePublicPrivate(@RequestUser UserInfo userInfo,
                                                      @PathVariable Long archiveId,

--- a/archive-web/src/main/java/site/archive/web/api/v2/ArchiveImageControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/ArchiveImageControllerV2.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -10,20 +9,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import site.archive.common.FileUtils;
 import site.archive.dto.v1.archive.ArchiveImageUrlResponseDtoV1;
 import site.archive.service.archive.ArchiveImageService;
-import site.archive.common.FileUtils;
+import site.archive.web.api.docs.swagger.ArchiveImageControllerV2Docs;
 
 import static site.archive.service.archive.ArchiveImageService.ARCHIVE_IMAGE_DIRECTORY;
 
 @RestController
 @RequestMapping("/api/v2/archive")
 @RequiredArgsConstructor
-public class ArchiveImageControllerV2 {
+public class ArchiveImageControllerV2 implements ArchiveImageControllerV2Docs {
 
     private final ArchiveImageService imageService;
 
-    @Operation(summary = "이미지 업로드")
     @PostMapping(path = "/image/upload",
                  consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
                  produces = MediaType.APPLICATION_JSON_VALUE)
@@ -33,7 +32,6 @@ public class ArchiveImageControllerV2 {
         return ResponseEntity.ok(new ArchiveImageUrlResponseDtoV1(imageUri));
     }
 
-    @Operation(summary = "이미지 제거")
     @DeleteMapping("/image/remove")
     public ResponseEntity<Void> removeImage(@RequestParam String fileUri) {
         imageService.remove(fileUri);

--- a/archive-web/src/main/java/site/archive/web/api/v2/ArchiveLikeControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/ArchiveLikeControllerV2.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,16 +10,16 @@ import site.archive.dto.v2.ArchiveLikeListResponseDto;
 import site.archive.service.archive.ArchiveService;
 import site.archive.service.like.LikeService;
 import site.archive.web.api.resolver.annotation.RequestUser;
+import site.archive.web.api.docs.swagger.ArchiveLikeControllerV2Docs;
 
 @RestController
 @RequestMapping("/api/v2/archive/like")
 @RequiredArgsConstructor
-public class ArchiveLikeControllerV2 {
+public class ArchiveLikeControllerV2 implements ArchiveLikeControllerV2Docs {
 
     private final ArchiveService archiveService;
     private final LikeService likeService;
 
-    @Operation(summary = "좋아요 한 Archive 조회")
     @GetMapping
     public ResponseEntity<ArchiveLikeListResponseDto> archiveLikeListView(@RequestUser UserInfo userInfo) {
         var archiveIds = likeService.likeArchiveIds(userInfo.getUserId());

--- a/archive-web/src/main/java/site/archive/web/api/v2/BannerControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/BannerControllerV2.java
@@ -45,8 +45,8 @@ public class BannerControllerV2 implements BannerControllerV2Docs {
     @PostMapping(path = "/type/image",
                  consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
                  produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> createArchiveCommunityBanner(@RequestParam MultipartFile summaryImage,
-                                                             @RequestParam MultipartFile mainImage) {
+    public ResponseEntity<Void> createArchiveCommunityBanner(@RequestParam(name = "summaryImage") MultipartFile summaryImage,
+                                                             @RequestParam(name = "mainImage") MultipartFile mainImage) {
         var summaryImageUri = imageUploadAndGetUri(BANNER_SUMMARY_IMAGE_DIRECTORY, summaryImage);
         var mainImageUri = imageUploadAndGetUri(BANNER_MAIN_IMAGE_DIRECTORY, mainImage);
         bannerService.createBanner(summaryImageUri, mainImageUri, BannerType.IMAGE);
@@ -58,7 +58,7 @@ public class BannerControllerV2 implements BannerControllerV2Docs {
     @PostMapping(path = "/type/url",
                  consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
                  produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> createArchiveCommunityBanner(@RequestParam MultipartFile summaryImage,
+    public ResponseEntity<Void> createArchiveCommunityBanner(@RequestParam(name = "summaryImage") MultipartFile summaryImage,
                                                              @RequestParam String mainContentUrl) {
         var summaryImageUri = imageUploadAndGetUri(BANNER_SUMMARY_IMAGE_DIRECTORY, summaryImage);
         bannerService.createBanner(summaryImageUri, mainContentUrl, BannerType.URL);

--- a/archive-web/src/main/java/site/archive/web/api/v2/BannerControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/BannerControllerV2.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -20,6 +19,7 @@ import site.archive.domain.banner.BannerType;
 import site.archive.dto.v2.BannerListResponseDto;
 import site.archive.service.archive.ArchiveImageService;
 import site.archive.service.banner.BannerService;
+import site.archive.web.api.docs.swagger.BannerControllerV2Docs;
 import site.archive.web.config.security.authz.AdminChecker;
 import site.archive.web.config.security.authz.annotation.RequirePermission;
 
@@ -29,19 +29,17 @@ import static site.archive.service.archive.ArchiveImageService.BANNER_SUMMARY_IM
 @RestController
 @RequestMapping("/api/v2/banner")
 @RequiredArgsConstructor
-public class BannerControllerV2 {
+public class BannerControllerV2 implements BannerControllerV2Docs {
 
     private final BannerService bannerService;
     private final ArchiveImageService imageService;
 
-    @Operation(summary = "배너 조회")
     @Cacheable(CacheInfo.BANNERS)
     @GetMapping
     public ResponseEntity<BannerListResponseDto> archiveCommunityBannerView() {
         return ResponseEntity.ok(bannerService.getAllBanner());
     }
 
-    @Operation(summary = "배너 생성 (업로드) - 이미지 타입")
     @CacheEvict(CacheInfo.BANNERS)
     @RequirePermission(handler = AdminChecker.class)
     @PostMapping(path = "/type/image",
@@ -55,7 +53,6 @@ public class BannerControllerV2 {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "배너 생성 (업로드) - URL 타입")
     @CacheEvict(CacheInfo.BANNERS)
     @RequirePermission(handler = AdminChecker.class)
     @PostMapping(path = "/type/url",
@@ -68,7 +65,6 @@ public class BannerControllerV2 {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "배너 제거")
     @CacheEvict(CacheInfo.BANNERS)
     @RequirePermission(handler = AdminChecker.class)
     @DeleteMapping("/{bannerId}")

--- a/archive-web/src/main/java/site/archive/web/api/v2/LikeControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/LikeControllerV2.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,36 +13,33 @@ import site.archive.dto.v2.LikesRequestDto;
 import site.archive.dto.v2.UnlikesRequestDto;
 import site.archive.service.like.LikeService;
 import site.archive.web.api.resolver.annotation.RequestUser;
+import site.archive.web.api.docs.swagger.LikeControllerV2Docs;
 
 @RestController
 @RequestMapping("/api/v2/archive/like")
 @RequiredArgsConstructor
-public class LikeControllerV2 {
+public class LikeControllerV2 implements LikeControllerV2Docs {
 
     private final LikeService likeService;
 
-    @Operation(summary = "좋아요 추가")
     @PostMapping("/{archiveId}")
     public ResponseEntity<Void> like(@RequestUser UserInfo user, @PathVariable Long archiveId) {
         likeService.save(user.getUserId(), archiveId);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "좋아요 추가 (Bulk)")
     @PostMapping
     public ResponseEntity<Void> likeBulk(@RequestUser UserInfo user, @RequestBody LikesRequestDto likesRequest) {
         likeService.save(user.getUserId(), likesRequest.getArchiveIds());
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "좋아요 삭제")
     @DeleteMapping("/{archiveId}")
     public ResponseEntity<Void> unlike(@RequestUser UserInfo user, @PathVariable Long archiveId) {
         likeService.delete(user.getUserId(), archiveId);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "좋아요 삭제 (Bulk)")
     @DeleteMapping
     public ResponseEntity<Void> unlikeBulk(@RequestUser UserInfo user, @RequestBody UnlikesRequestDto unlikesRequest) {
         likeService.delete(user.getUserId(), unlikesRequest.getArchiveIds());

--- a/archive-web/src/main/java/site/archive/web/api/v2/ReportControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/ReportControllerV2.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,35 +14,33 @@ import site.archive.dto.v2.ReportCheckResponse;
 import site.archive.dto.v2.ReportRequestDto;
 import site.archive.service.report.ReportService;
 import site.archive.web.api.resolver.annotation.RequestUser;
+import site.archive.web.api.docs.swagger.ReportControllerV2Docs;
 
 @RestController
 @RequestMapping("/api/v2/report")
 @RequiredArgsConstructor
-public class ReportControllerV2 {
+public class ReportControllerV2 implements ReportControllerV2Docs {
 
     private final ReportService reportService;
 
-    @Operation(summary = "신고 여부 확인")
     @GetMapping("/{archiveId}")
-    public ResponseEntity<ReportCheckResponse> isReport(@PathVariable Long archiveId,
-                                                        @RequestUser UserInfo userInfo) {
+    public ResponseEntity<ReportCheckResponse> isReport(@RequestUser UserInfo userInfo,
+                                                        @PathVariable Long archiveId) {
         var isReported = reportService.isReportedBy(archiveId, userInfo.getUserId());
         return ResponseEntity.ok(new ReportCheckResponse(isReported));
     }
 
-    @Operation(summary = "신고하기")
     @PostMapping("/{archiveId}")
-    public ResponseEntity<Void> report(@PathVariable Long archiveId,
-                                       @RequestUser UserInfo userInfo,
+    public ResponseEntity<Void> report(@RequestUser UserInfo userInfo,
+                                       @PathVariable Long archiveId,
                                        @RequestBody ReportRequestDto reportRequestDto) {
         reportService.reportArchive(archiveId, userInfo.getUserId(), reportRequestDto.getReason());
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "신고 취소하기")
     @DeleteMapping("/{archiveId}")
-    public ResponseEntity<Void> reportCancel(@PathVariable Long archiveId,
-                                             @RequestUser UserInfo userInfo) {
+    public ResponseEntity<Void> reportCancel(@RequestUser UserInfo userInfo,
+                                             @PathVariable Long archiveId) {
         reportService.cancelReportArchive(archiveId, userInfo.getUserId());
         return ResponseEntity.noContent().build();
     }

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserAuthControllerV2.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,12 +19,13 @@ import site.archive.service.user.UserAuthService;
 import site.archive.service.user.UserRegisterServiceV2;
 import site.archive.service.user.UserService;
 import site.archive.web.api.resolver.annotation.RequestUser;
+import site.archive.web.api.docs.swagger.UserAuthControllerV2Docs;
 import site.archive.web.config.security.token.jwt.JwtAuthenticationToken;
 
 @RestController
 @RequestMapping("/api/v2/auth")
 @RequiredArgsConstructor
-public class UserAuthControllerV2 {
+public class UserAuthControllerV2 implements UserAuthControllerV2Docs {
 
     private final UserService userService;
     private final UserAuthService userAuthService;
@@ -33,7 +33,6 @@ public class UserAuthControllerV2 {
     private final OAuthUserService oAuthUserService;
     private final PasswordEncoder encoder;
 
-    @Operation(summary = "비밀번호 초기화 - 새로운 비밀번호 설정")
     @PostMapping("/password/reset")
     public ResponseEntity<Void> resetPassword(@RequestUser UserInfo userInfo,
                                               @Validated @RequestBody UserPasswordResetRequestDtoV1 userPasswordResetRequestDtoV1) {
@@ -41,7 +40,6 @@ public class UserAuthControllerV2 {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "[NoAuth] 패스워드 유저 회원가입")
     @PostMapping("/register")
     public ResponseEntity<Void> registerPasswordUser(@Validated @RequestBody PasswordRegisterRequestDto passwordRegisterRequest) {
         passwordRegisterRequest.updatePasswordToEncrypt(encoder.encode(passwordRegisterRequest.getPassword()));
@@ -50,7 +48,6 @@ public class UserAuthControllerV2 {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "[NoAuth] 소셜 유저 회원가입")
     @PostMapping("/register/social")
     public ResponseEntity<Void> registerSocialUser(@Validated @RequestBody OAuthUserInfoRequestDto oAuthUserInfoRequest) {
         var oAuthRegisterRequest = oAuthUserService.getOAuthRegisterInfo(oAuthUserInfoRequest);
@@ -59,7 +56,6 @@ public class UserAuthControllerV2 {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "[NoAuth] 소셜 유저 로그인")
     @PostMapping("/login/social")
     public ResponseEntity<Void> loginSocialUser(@Validated @RequestBody OAuthLoginRequestDto oAuthLoginRequestDto) {
         var oAuthEmail = oAuthUserService.getOAuthEmail(oAuthLoginRequestDto);

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserControllerV2.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,21 +22,18 @@ public class UserControllerV2 {
 
     private final UserService userService;
 
-    @Operation(summary = "[NoAuth] 이메일 중복 검사")
     @GetMapping("/duplicate/email")
     public ResponseEntity<EmailDuplicateResponseDtoV1> checkDuplicatedEmail(@RequestParam(value = "value") String email) {
         var emailDuplicateResponseDto = new EmailDuplicateResponseDtoV1(userService.existsEmail(email));
         return ResponseEntity.ok(emailDuplicateResponseDto);
     }
 
-    @Operation(summary = "[NoAuth] 닉네임 중복 검사")
     @GetMapping("/duplicate/nickname")
     public ResponseEntity<NicknameDuplicateResponseDto> checkDuplicatedNickname(@RequestParam(value = "value") String nickname) {
         var nicknameDuplicateResponseDto = new NicknameDuplicateResponseDto(userService.existsNickname(nickname));
         return ResponseEntity.ok(nicknameDuplicateResponseDto);
     }
 
-    @Operation(summary = "프로필 닉네임 수정 (업데이트)")
     @PutMapping("/nickname")
     public ResponseEntity<Void> updateProfileNickname(@RequestUser UserInfo user,
                                                       @RequestBody UserNicknameUpdateRequest request) {

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserControllerV2.java
@@ -13,12 +13,13 @@ import site.archive.dto.v1.archive.EmailDuplicateResponseDtoV1;
 import site.archive.dto.v2.NicknameDuplicateResponseDto;
 import site.archive.dto.v2.UserNicknameUpdateRequest;
 import site.archive.service.user.UserService;
+import site.archive.web.api.docs.swagger.UserControllerV2Docs;
 import site.archive.web.api.resolver.annotation.RequestUser;
 
 @RestController
 @RequestMapping("/api/v2/user")
 @RequiredArgsConstructor
-public class UserControllerV2 {
+public class UserControllerV2 implements UserControllerV2Docs {
 
     private final UserService userService;
 

--- a/archive-web/src/main/java/site/archive/web/api/v2/UserProfileControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/UserProfileControllerV2.java
@@ -1,6 +1,5 @@
 package site.archive.web.api.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -11,32 +10,31 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import site.archive.common.FileUtils;
 import site.archive.domain.user.UserInfo;
 import site.archive.dto.v1.user.SpecificUserDtoV1;
 import site.archive.service.archive.ArchiveImageService;
 import site.archive.service.user.UserProfileImageService;
 import site.archive.service.user.UserService;
 import site.archive.web.api.resolver.annotation.RequestUser;
-import site.archive.common.FileUtils;
+import site.archive.web.api.docs.swagger.UserProfileControllerV2Docs;
 
 import static site.archive.service.archive.ArchiveImageService.USER_PROFILE_IMAGE_DIRECTORY;
 
 @RestController
 @RequestMapping("/api/v2/user/profile")
 @RequiredArgsConstructor
-public class UserProfileControllerV2 {
+public class UserProfileControllerV2 implements UserProfileControllerV2Docs {
 
     private final UserService userService;
     private final UserProfileImageService userProfileImageService;
     private final ArchiveImageService imageService;
 
-    @Operation(summary = "프로필 정보 조회")
     @GetMapping
     public ResponseEntity<SpecificUserDtoV1> getUserProfileInfo(@RequestUser UserInfo user) {
         return ResponseEntity.ok(userService.findSpecificUserById(user.getUserId()));
     }
 
-    @Operation(summary = "프로필 이미지 업로드 및 업데이트")
     @PostMapping(path = "/image/upload",
                  consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
                  produces = MediaType.APPLICATION_JSON_VALUE)
@@ -51,7 +49,6 @@ public class UserProfileControllerV2 {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "프로필 이미지 제거")
     @DeleteMapping(path = "/image/remove")
     public ResponseEntity<Void> removeProfileImage(@RequestUser UserInfo user) {
         var outdatedImageUri = userService.findUserById(user.getUserId()).getProfileImage();


### PR DESCRIPTION
springdoc-openapi를 이용해 Swagger (API document)를 위한 Controller interface 생성
- API Document에 대한 책임 분리
- Controller 코드 간결화, 가독성 향상, 하나의 목적
- API First design이 가능하지 않으려나