### PR TITLE
fix: added CacheEvict allEntries option

### DIFF
--- a/archive-common/src/main/kotlin/site/archive/common/cache/CacheType.kt
+++ b/archive-common/src/main/kotlin/site/archive/common/cache/CacheType.kt
@@ -2,18 +2,18 @@ package site.archive.common.cache
 
 enum class CacheType(val key: String, val expireAfterWrite: Int, val maximumSize: Int) {
 
-    BANNERS(CacheInfo.BANNERS, CacheInfo.BANNERS_GET_EXPIRE_TIME, CacheInfo.BANNERS_CACHE_SIZE),
-    ARCHIVE_COMMUNITIES(CacheInfo.ARCHIVE_COMMUNITIES, CacheInfo.ARCHIVE_COMMUNITIES_GET_EXPIRE_TIME, CacheInfo.ARCHIVE_COMMUNITIES_CACHE_SIZE)
+    BANNERS(CacheInfo.BANNERS, CacheInfo.BANNERS_GET_EXPIRE_SECONDS, CacheInfo.BANNERS_CACHE_SIZE),
+    ARCHIVE_COMMUNITIES(CacheInfo.ARCHIVE_COMMUNITIES, CacheInfo.ARCHIVE_COMMUNITIES_GET_EXPIRE_SECONDS, CacheInfo.ARCHIVE_COMMUNITIES_CACHE_SIZE)
     ;
 
     class CacheInfo {
         companion object {
             const val BANNERS: String = "banners"
-            const val BANNERS_GET_EXPIRE_TIME: Int = 3_600
+            const val BANNERS_GET_EXPIRE_SECONDS: Int = 3_600
             const val BANNERS_CACHE_SIZE: Int = 1
 
             const val ARCHIVE_COMMUNITIES: String = "archive-communities"
-            const val ARCHIVE_COMMUNITIES_GET_EXPIRE_TIME: Int = 30
+            const val ARCHIVE_COMMUNITIES_GET_EXPIRE_SECONDS: Int = 30
             const val ARCHIVE_COMMUNITIES_CACHE_SIZE: Int = 200
         }
     }

--- a/archive-web/src/main/java/site/archive/web/api/v2/BannerControllerV2.java
+++ b/archive-web/src/main/java/site/archive/web/api/v2/BannerControllerV2.java
@@ -40,7 +40,7 @@ public class BannerControllerV2 implements BannerControllerV2Docs {
         return ResponseEntity.ok(bannerService.getAllBanner());
     }
 
-    @CacheEvict(CacheInfo.BANNERS)
+    @CacheEvict(value = CacheInfo.BANNERS, allEntries = true)
     @RequirePermission(handler = AdminChecker.class)
     @PostMapping(path = "/type/image",
                  consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
@@ -53,7 +53,7 @@ public class BannerControllerV2 implements BannerControllerV2Docs {
         return ResponseEntity.noContent().build();
     }
 
-    @CacheEvict(CacheInfo.BANNERS)
+    @CacheEvict(value = CacheInfo.BANNERS, allEntries = true)
     @RequirePermission(handler = AdminChecker.class)
     @PostMapping(path = "/type/url",
                  consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
@@ -65,7 +65,7 @@ public class BannerControllerV2 implements BannerControllerV2Docs {
         return ResponseEntity.noContent().build();
     }
 
-    @CacheEvict(CacheInfo.BANNERS)
+    @CacheEvict(value = CacheInfo.BANNERS, allEntries = true)
     @RequirePermission(handler = AdminChecker.class)
     @DeleteMapping("/{bannerId}")
     public ResponseEntity<Void> deleteArchiveCommunityBanner(@PathVariable Long bannerId) {


### PR DESCRIPTION
- added CacheEvict `allEntries = true` option to banner controller
- rename expireAfterWrite variable name - added 'SECONDS' suffix